### PR TITLE
fix UPDATE BYTES to default values

### DIFF
--- a/internal/hammer/ddl.go
+++ b/internal/hammer/ddl.go
@@ -60,7 +60,7 @@ func (u Update) defaultValue() string {
 	case spansql.String:
 		return "''"
 	case spansql.Bytes:
-		return "CAST('' AS BYTES)"
+		return "b''"
 	case spansql.Date:
 		return "'0001-01-01'"
 	case spansql.Timestamp:

--- a/internal/hammer/ddl.go
+++ b/internal/hammer/ddl.go
@@ -57,8 +57,10 @@ func (u Update) defaultValue() string {
 		return "false"
 	case spansql.Int64, spansql.Float64:
 		return "0"
-	case spansql.String, spansql.Bytes:
+	case spansql.String:
 		return "''"
+	case spansql.Bytes:
+		return "CAST('' AS BYTES)"
 	case spansql.Date:
 		return "'0001-01-01'"
 	case spansql.Timestamp:

--- a/internal/hammer/ddl_test.go
+++ b/internal/hammer/ddl_test.go
@@ -61,6 +61,10 @@ func TestUpdate_SQL(t *testing.T) {
 			s: "UPDATE test_table SET test_column = '' WHERE test_column IS NULL",
 		},
 		{
+			d: spansql.ColumnDef{Name: "test_column", Type: spansql.Type{Base: spansql.Bytes}},
+			s: "UPDATE test_table SET test_column = CAST('' AS BYTES) WHERE test_column IS NULL",
+		},
+		{
 			d: spansql.ColumnDef{Name: "test_column", Type: spansql.Type{Base: spansql.String, Array: true}},
 			s: "UPDATE test_table SET test_column = [] WHERE test_column IS NULL",
 		},

--- a/internal/hammer/ddl_test.go
+++ b/internal/hammer/ddl_test.go
@@ -62,7 +62,7 @@ func TestUpdate_SQL(t *testing.T) {
 		},
 		{
 			d: spansql.ColumnDef{Name: "test_column", Type: spansql.Type{Base: spansql.Bytes}},
-			s: "UPDATE test_table SET test_column = CAST('' AS BYTES) WHERE test_column IS NULL",
+			s: "UPDATE test_table SET test_column = b'' WHERE test_column IS NULL",
 		},
 		{
 			d: spansql.ColumnDef{Name: "test_column", Type: spansql.Type{Base: spansql.String, Array: true}},


### PR DESCRIPTION
Hi! 

I fixed case that updating `BYTES` default value when adding `BYTES` column with `NOT NULL`.

### reproduce
schema diff
```diff
>   bytes BYTES(MAX) NOT NULL,
```
hammer diff
```
ALTER TABLE test ADD COLUMN bytes BYTES(MAX)
UPDATE test SET bytes = '' WHERE bytes IS NULL
ALTER TABLE test ALTER COLUMN bytes BYTES(MAX) NOT NULL
```
hammer apply error
```
Error: rpc error: code = InvalidArgument desc = Value of type STRING cannot be assigned to bytes, which has type BYTES [at 1:25]\nUPDATE test SET bytes = \'\' WHERE bytes IS NULL\n
```
