### PR TITLE
Fix command exit code

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"os"
+
 	"github.com/daichirata/hammer/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Currently, hammer does not check the result of a command
- if the command fails, an error is shown which is helpful to
a user visually but hammer exits with code `0` which means it
can't be very useful as an automation tool.
This patch checks command results and exits with a non-zero code
if the command failed.

Before:
```bash
$ hammer diff non-existent-file-a non-existent-file-b
Error: open non-existent-file-a: no such file or directory
$ echo $?
0
```

After applying patch
```bash
$ hammer diff non-existent-file-a non-existent-file-b
Error: open non-existent-file-a: no such file or directory
$ echo $?
1
```