### PR TITLE
Add release workflow to provide multiple binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13.x
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,46 @@
+before:
+  hooks:
+    - go mod download
+builds:
+  - main: .
+    binary: hammer
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - 386
+    ignore:
+      - goos: darwin
+        goarch: 386
+
+archives:
+  - format: tar.gz
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "SNAPSHOT-{{ .Tag }}"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^test:'
+      - 'README'
+      - Merge pull request
+      - Merge branch


### PR DESCRIPTION
This PR Fixes #16 by providing multiple binaries below automatically at each release.

```
hammer-0.4.0-darwin-amd64.tar.gz
hammer-0.4.0-linux-386.tar.gz
hammer-0.4.0-linux-amd64.tar.gz
hammer-0.4.0-linux-arm64.tar.gz
hammer-0.4.0-linux-armv6.tar.gz
hammer-0.4.0-windows-386.zip
hammer-0.4.0-windows-amd64.zip
```