### PR TITLE
Separate queries of `hammer diff` with semicolon.

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -59,7 +59,7 @@ var (
 				return err
 			}
 			for _, stmt := range ddl.List {
-				fmt.Println(stmt.SQL())
+				fmt.Println(stmt.SQL() + ";")
 			}
 			return nil
 		},


### PR DESCRIPTION
Fixes #22 