### PR TITLE
Quote column names in UPDATE statement

### DIFF
--- a/internal/hammer/ddl.go
+++ b/internal/hammer/ddl.go
@@ -86,5 +86,5 @@ func (u Update) defaultValue() string {
 }
 
 func (u Update) SQL() string {
-	return fmt.Sprintf("UPDATE %s SET %s = %s WHERE %s IS NULL", u.Table, u.Def.Name, u.defaultValue(), u.Def.Name)
+	return fmt.Sprintf("UPDATE %s SET %s = %s WHERE %s IS NULL", u.Table.SQL(), u.Def.Name.SQL(), u.defaultValue(), u.Def.Name.SQL())
 }

--- a/internal/hammer/ddl_test.go
+++ b/internal/hammer/ddl_test.go
@@ -95,6 +95,10 @@ func TestUpdate_SQL(t *testing.T) {
 			d: spansql.ColumnDef{Name: "test_column", Type: spansql.Type{Base: spansql.Timestamp}},
 			s: "UPDATE test_table SET test_column = '0001-01-01 00:00:00' WHERE test_column IS NULL",
 		},
+		{
+			d: spansql.ColumnDef{Name: "order", Type: spansql.Type{Base: spansql.Int64}},
+			s: "UPDATE test_table SET `order` = 0 WHERE `order` IS NULL",
+		},
 	}
 	for _, v := range values {
 		actual := hammer.Update{Table: "test_table", Def: v.d}.SQL()


### PR DESCRIPTION
Identifiers should be quoted using `spansql.ID.SQL()`.
All identifiers except for those in UPDATE are quoted correctly as far as I can see.