### PR TITLE
Fix default value of timestamp

### DIFF
--- a/internal/hammer/ddl.go
+++ b/internal/hammer/ddl.go
@@ -79,7 +79,7 @@ func (u Update) defaultValue() string {
 	case spansql.Date:
 		return "'0001-01-01'"
 	case spansql.Timestamp:
-		return "'0001-01-01 00:00:00'"
+		return "'0001-01-01T00:00:00Z'"
 	default:
 		return "''"
 	}

--- a/internal/hammer/ddl_test.go
+++ b/internal/hammer/ddl_test.go
@@ -93,7 +93,7 @@ func TestUpdate_SQL(t *testing.T) {
 		},
 		{
 			d: spansql.ColumnDef{Name: "test_column", Type: spansql.Type{Base: spansql.Timestamp}},
-			s: "UPDATE test_table SET test_column = '0001-01-01 00:00:00' WHERE test_column IS NULL",
+			s: "UPDATE test_table SET test_column = '0001-01-01T00:00:00Z' WHERE test_column IS NULL",
 		},
 		{
 			d: spansql.ColumnDef{Name: "order", Type: spansql.Type{Base: spansql.Int64}},

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -170,7 +170,7 @@ CREATE TABLE t1 (
 ) PRIMARY KEY(t1_1);
 `,
 			expected: []string{
-				`UPDATE t1 SET t1_2 = '0001-01-01 00:00:00' WHERE t1_2 IS NULL`,
+				`UPDATE t1 SET t1_2 = '0001-01-01T00:00:00Z' WHERE t1_2 IS NULL`,
 				`ALTER TABLE t1 ALTER COLUMN t1_2 TIMESTAMP NOT NULL`,
 			},
 		},
@@ -225,7 +225,7 @@ CREATE TABLE t1 (
 ) PRIMARY KEY(t1_1);
 `,
 			expected: []string{
-				`UPDATE t1 SET t1_2 = '0001-01-01 00:00:00' WHERE t1_2 IS NULL`,
+				`UPDATE t1 SET t1_2 = '0001-01-01T00:00:00Z' WHERE t1_2 IS NULL`,
 				`ALTER TABLE t1 ALTER COLUMN t1_2 TIMESTAMP NOT NULL`,
 				`ALTER TABLE t1 ALTER COLUMN t1_2 SET OPTIONS (allow_commit_timestamp = true)`,
 			},


### PR DESCRIPTION
Fixed when updating the initial timestamp value, the value may be corrupted if the time zone is not specified.