### PR TITLE
support altering generated column

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or
 $ go get -u github.com/daichirata/hammer
 ```
 
-## Useage
+## Usage
 
 ```
 $ hammer -h

--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -326,7 +326,7 @@ func (g *Generator) generateDDLForColumns(from, to *Table) DDL {
 		fromCol, exists := g.findColumnByName(from.Columns, toCol.Name)
 
 		if !exists {
-			if toCol.NotNull {
+			if toCol.NotNull && toCol.Generated == nil {
 				ddl.Append(spansql.AlterTable{Name: to.Name, Alteration: spansql.AddColumn{Def: g.allowNull(toCol)}})
 				ddl.Append(Update{Table: to.Name, Def: toCol})
 				ddl.Append(AlterColumn{Table: to.Name, Def: toCol})
@@ -340,7 +340,7 @@ func (g *Generator) generateDDLForColumns(from, to *Table) DDL {
 			continue
 		}
 
-		if g.columnTypeEqual(fromCol, toCol) {
+		if g.columnTypeEqual(fromCol, toCol) && fromCol.Generated == nil && toCol.Generated == nil {
 			if fromCol.Type.Base == spansql.Timestamp {
 				if fromCol.NotNull != toCol.NotNull {
 					if !fromCol.NotNull && toCol.NotNull {
@@ -415,7 +415,7 @@ func (g *Generator) generateDDLForDropAndCreateColumn(from, to *Table, fromCol, 
 
 	ddl.AppendDDL(g.generateDDLForDropColumn(from.Name, fromCol.Name))
 
-	if toCol.NotNull {
+	if toCol.NotNull && toCol.Generated == nil {
 		ddl.Append(spansql.AlterTable{Name: to.Name, Alteration: spansql.AddColumn{Def: g.allowNull(toCol)}})
 		ddl.Append(Update{Table: to.Name, Def: toCol})
 		ddl.Append(AlterColumn{Table: to.Name, Def: toCol})


### PR DESCRIPTION
I added support for "generated column" on the diff generator.

- Generated columns do not accept `ALTER COLUMN`, then must be re-created using `DROP` and `ADD`.
    - https://cloud.google.com/spanner/docs/generated-column/how-to#modify-generated-column
- Generated columns with `NOT NULL` constraint have not to set zero value.
