### PR TITLE
Add option to ignore `ALTER DATABASE` statement

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -41,12 +41,19 @@ var (
 			if err != nil {
 				return err
 			}
-
-			databaseDDL, err := database.DDL(ctx)
+			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
 			if err != nil {
 				return err
 			}
-			sourceDDL, err := source.DDL(ctx)
+			ddlOption := &hammer.DDLOption{
+				IgnoreAlterDatabase: ignoreAlterDatabase,
+			}
+
+			databaseDDL, err := database.DDL(ctx, ddlOption)
+			if err != nil {
+				return err
+			}
+			sourceDDL, err := source.DDL(ctx, ddlOption)
 			if err != nil {
 				return err
 			}
@@ -68,5 +75,7 @@ var (
 )
 
 func init() {
+	applyCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
+
 	rootCmd.AddCommand(applyCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	"github.com/daichirata/hammer/internal/hammer"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -44,8 +43,15 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
+			if err != nil {
+				return err
+			}
+			ddlOption := &hammer.DDLOption{
+				IgnoreAlterDatabase: ignoreAlterDatabase,
+			}
 
-			ddl, err := source.DDL(ctx)
+			ddl, err := source.DDL(ctx, ddlOption)
 			if err != nil {
 				return err
 			}
@@ -55,5 +61,7 @@ var (
 )
 
 func init() {
+	createCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
+
 	rootCmd.AddCommand(createCmd)
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -44,12 +44,19 @@ var (
 			if err != nil {
 				return err
 			}
-
-			ddl1, err := source1.DDL(ctx)
+			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
 			if err != nil {
 				return err
 			}
-			ddl2, err := source2.DDL(ctx)
+			ddlOption := &hammer.DDLOption{
+				IgnoreAlterDatabase: ignoreAlterDatabase,
+			}
+
+			ddl1, err := source1.DDL(ctx, ddlOption)
+			if err != nil {
+				return err
+			}
+			ddl2, err := source2.DDL(ctx, ddlOption)
 			if err != nil {
 				return err
 			}
@@ -67,5 +74,7 @@ var (
 )
 
 func init() {
+	diffCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
+
 	rootCmd.AddCommand(diffCmd)
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -28,12 +28,19 @@ var (
 			ctx := context.Background()
 
 			sourceURI := args[0]
+			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
+			if err != nil {
+				return err
+			}
+			ddlOption := &hammer.DDLOption{
+				IgnoreAlterDatabase: ignoreAlterDatabase,
+			}
 
 			source, err := hammer.NewSource(ctx, sourceURI)
 			if err != nil {
 				return err
 			}
-			ddl, err := source.DDL(ctx)
+			ddl, err := source.DDL(ctx, ddlOption)
 			if err != nil {
 				return err
 			}
@@ -46,5 +53,6 @@ var (
 )
 
 func init() {
+	exportCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	rootCmd.AddCommand(exportCmd)
 }

--- a/internal/hammer/ddl.go
+++ b/internal/hammer/ddl.go
@@ -22,14 +22,17 @@ func (d *DDL) AppendDDL(ddl DDL) {
 	d.Append(ddl.List...)
 }
 
-func ParseDDL(uri, schema string) (DDL, error) {
+func ParseDDL(uri, schema string, option *DDLOption) (DDL, error) {
 	ddl, err := spansql.ParseDDL(uri, schema)
 	if err != nil {
 		return DDL{}, fmt.Errorf("%s failed to parse ddl: %s", uri, err)
 	}
-	list := make([]Statement, len(ddl.List))
-	for i, stmt := range ddl.List {
-		list[i] = stmt
+	list := make([]Statement, 0, len(ddl.List))
+	for _, stmt := range ddl.List {
+		if _, ok := stmt.(*spansql.AlterDatabase); ok && option.IgnoreAlterDatabase {
+			continue
+		}
+		list = append(list, stmt)
 	}
 	return DDL{List: list}, nil
 }


### PR DESCRIPTION
Added `--ignore-alter-database` option to ignore `ALTER DATABASE` statement, for all 4 commands (apply, create, diff, export)

Fixes: #34