### PR TITLE
Add ignore-change-streams flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hammer 
+# hammer
 
 hammer is a command-line tool to schema management for Google Cloud Spanner.
 
@@ -13,7 +13,7 @@ https://github.com/daichirata/hammer/releases
 or
 
 ``` shell
-$ go get -u github.com/daichirata/hammer
+$ go install github.com/daichirata/hammer@latest
 ```
 
 ## Usage
@@ -73,6 +73,15 @@ spanner://projects/{projectId}/instances/{instanceId}/databases/{databaseName}?c
 | `instanceId`   | true     | The id of the instance running Spanner                                                         |
 | `databaseName` | true     | The name of the Spanner database                                                               |
 | `credentials`  | false    | The path to the keyfile. If not present, client will use your default application credentials. |
+
+### Flags
+
+apply, create, diff and export can accept the flags defined below
+
+```
+--ignore-alter-database   ignore alter database statements
+--ignore-change-streams   ignore change streams statements
+```
 
 ### Examples
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -30,6 +30,19 @@ var (
 			databaseURI := args[0]
 			sourceURI := args[1]
 
+			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
+			if err != nil {
+				return err
+			}
+			ignoreChangeStreams, err := cmd.Flags().GetBool("ignore-change-streams")
+			if err != nil {
+				return err
+			}
+			ddlOption := &hammer.DDLOption{
+				IgnoreAlterDatabase: ignoreAlterDatabase,
+				IgnoreChangeStreams: ignoreChangeStreams,
+			}
+
 			if hammer.Scheme(databaseURI) != "spanner" {
 				return fmt.Errorf("DATABASE must be a spanner URI")
 			}
@@ -40,13 +53,6 @@ var (
 			source, err := hammer.NewSource(ctx, sourceURI)
 			if err != nil {
 				return err
-			}
-			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
-			if err != nil {
-				return err
-			}
-			ddlOption := &hammer.DDLOption{
-				IgnoreAlterDatabase: ignoreAlterDatabase,
 			}
 
 			databaseDDL, err := database.DDL(ctx, ddlOption)
@@ -76,6 +82,7 @@ var (
 
 func init() {
 	applyCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
+	applyCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
 
 	rootCmd.AddCommand(applyCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -32,6 +32,19 @@ var (
 			databaseURI := args[0]
 			sourceURI := args[1]
 
+			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
+			if err != nil {
+				return err
+			}
+			ignoreChangeStreams, err := cmd.Flags().GetBool("ignore-change-streams")
+			if err != nil {
+				return err
+			}
+			ddlOption := &hammer.DDLOption{
+				IgnoreAlterDatabase: ignoreAlterDatabase,
+				IgnoreChangeStreams: ignoreChangeStreams,
+			}
+
 			if hammer.Scheme(databaseURI) != "spanner" {
 				return fmt.Errorf("DATABASE must be a spanner URI")
 			}
@@ -42,13 +55,6 @@ var (
 			source, err := hammer.NewSource(ctx, sourceURI)
 			if err != nil {
 				return err
-			}
-			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
-			if err != nil {
-				return err
-			}
-			ddlOption := &hammer.DDLOption{
-				IgnoreAlterDatabase: ignoreAlterDatabase,
 			}
 
 			ddl, err := source.DDL(ctx, ddlOption)
@@ -62,6 +68,7 @@ var (
 
 func init() {
 	createCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
+	createCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
 
 	rootCmd.AddCommand(createCmd)
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -36,6 +36,19 @@ var (
 			sourceURI1 := args[0]
 			sourceURI2 := args[1]
 
+			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
+			if err != nil {
+				return err
+			}
+			ignoreChangeStreams, err := cmd.Flags().GetBool("ignore-change-streams")
+			if err != nil {
+				return err
+			}
+			ddlOption := &hammer.DDLOption{
+				IgnoreAlterDatabase: ignoreAlterDatabase,
+				IgnoreChangeStreams: ignoreChangeStreams,
+			}
+
 			source1, err := hammer.NewSource(ctx, sourceURI1)
 			if err != nil {
 				return err
@@ -43,13 +56,6 @@ var (
 			source2, err := hammer.NewSource(ctx, sourceURI2)
 			if err != nil {
 				return err
-			}
-			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
-			if err != nil {
-				return err
-			}
-			ddlOption := &hammer.DDLOption{
-				IgnoreAlterDatabase: ignoreAlterDatabase,
 			}
 
 			ddl1, err := source1.DDL(ctx, ddlOption)
@@ -75,6 +81,7 @@ var (
 
 func init() {
 	diffCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
+	diffCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
 
 	rootCmd.AddCommand(diffCmd)
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -28,18 +28,25 @@ var (
 			ctx := context.Background()
 
 			sourceURI := args[0]
+
 			ignoreAlterDatabase, err := cmd.Flags().GetBool("ignore-alter-database")
+			if err != nil {
+				return err
+			}
+			ignoreChangeStreams, err := cmd.Flags().GetBool("ignore-change-streams")
 			if err != nil {
 				return err
 			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
+				IgnoreChangeStreams: ignoreChangeStreams,
 			}
 
 			source, err := hammer.NewSource(ctx, sourceURI)
 			if err != nil {
 				return err
 			}
+
 			ddl, err := source.DDL(ctx, ddlOption)
 			if err != nil {
 				return err
@@ -54,5 +61,7 @@ var (
 
 func init() {
 	exportCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
+	exportCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
+
 	rootCmd.AddCommand(exportCmd)
 }

--- a/internal/hammer/source.go
+++ b/internal/hammer/source.go
@@ -15,6 +15,7 @@ type Source interface {
 
 type DDLOption struct {
 	IgnoreAlterDatabase bool
+	IgnoreChangeStreams bool
 }
 
 func NewSource(ctx context.Context, uri string) (Source, error) {


### PR DESCRIPTION
The library called spansql used by hammer cannot parse change streams definitions, so I added a flag to ignore DDL starting with `CREATE CHANGE STREAM`.

The default value of the flag is set to false, as we would like to support change streams in the future.

related #41 