### PR TITLE
fix: fix timestamp with default fields comparison

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -611,7 +611,7 @@ func (g *Generator) primaryKeyEqual(x, y *Table) bool {
 }
 
 func (g *Generator) columnDefEqual(x, y spansql.ColumnDef) bool {
-	return cmp.Equal(x, y, cmpopts.IgnoreTypes(spansql.Position{}))
+	return cmp.Equal(x, y, cmpopts.IgnoreTypes(spansql.Position{}), cmpopts.IgnoreUnexported(spansql.TimestampLiteral{}))
 }
 
 func (g *Generator) columnTypeEqual(x, y spansql.ColumnDef) bool {

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -1361,6 +1361,23 @@ CREATE CHANGE STREAM SomeStream FOR ALL;
 			ignoreAlterDatabase: true,
 			expected:            []string{"ALTER CHANGE STREAM SomeStream SET OPTIONS (retention_period='1d', value_capture_type='OLD_AND_NEW_VALUES')"},
 		},
+		{
+			name: "both sides have identical fields of timestamp with a default value",
+			from: `
+CREATE TABLE Nonces (
+  nonce INT64 NOT NULL,
+  expires TIMESTAMP NOT NULL DEFAULT(TIMESTAMP '2000-01-01 00:00:00.000000+00:00'),
+) PRIMARY KEY(nonce);
+`,
+			to: `
+CREATE TABLE Nonces (
+  nonce INT64 NOT NULL,
+  expires TIMESTAMP NOT NULL DEFAULT(TIMESTAMP '2000-01-01 00:00:00.000000+00:00'),
+) PRIMARY KEY(nonce);
+`,
+			ignoreAlterDatabase: true,
+			expected:            []string{},
+		},
 	}
 	for _, v := range values {
 		t.Run(v.name, func(t *testing.T) {


### PR DESCRIPTION
If both sides have identical columns of timestamp with a default value,

```sql
CREATE TABLE  (
  column TIMESTAMP NOT NULL DEFAULT(TIMESTAMP '2000-01-01 00:00:00.000000+00:00'),
  …
```

it panics:
```
panic: cannot handle unexported field at {spansql.ColumnDef}.Default.(spansql.TimestampLiteral).wall:
	"cloud.google.com/go/spanner/spansql".TimestampLiteral
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported [recovered]
	panic: cannot handle unexported field at {spansql.ColumnDef}.Default.(spansql.TimestampLiteral).wall:
	"cloud.google.com/go/spanner/spansql".TimestampLiteral
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported
```

test that reproduces:

https://github.com/murasaki-bv/hammer/blob/f8af0e9e7cd4b06716aee0fdffe46c21db6aa690/internal/hammer/diff_test.go#L1364-L1381
