### PR TITLE
Fix case-sensitive table and column names

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -3,6 +3,7 @@ package hammer
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/spanner/spansql"
@@ -635,6 +636,9 @@ func (g *Generator) primaryKeyEqual(x, y *Table) bool {
 
 func (g *Generator) columnDefEqual(x, y spansql.ColumnDef) bool {
 	return cmp.Equal(x, y,
+		cmp.Comparer(func(x, y spansql.ID) bool {
+			return strings.EqualFold(string(x), string(y))
+		}),
 		cmpopts.IgnoreTypes(spansql.Position{}),
 		cmp.Comparer(func(x, y spansql.TimestampLiteral) bool {
 			return time.Time(x).Equal(time.Time(y))
@@ -695,7 +699,7 @@ func (g *Generator) setDefault(col spansql.ColumnDef) spansql.ColumnDef {
 
 func (g *Generator) findTableByName(tables []*Table, name spansql.ID) (table *Table, exists bool) {
 	for _, t := range tables {
-		if t.Name == name {
+		if strings.EqualFold(string(t.Name), string(name)) {
 			table = t
 			exists = true
 			break
@@ -706,7 +710,7 @@ func (g *Generator) findTableByName(tables []*Table, name spansql.ID) (table *Ta
 
 func (g *Generator) findColumnByName(cols []spansql.ColumnDef, name spansql.ID) (col spansql.ColumnDef, exists bool) {
 	for _, c := range cols {
-		if c.Name == name {
+		if strings.EqualFold(string(c.Name), string(name)) {
 			col = c
 			exists = true
 			break

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -1451,6 +1451,22 @@ AS SELECT * FROM t1;
 				`CREATE OR REPLACE VIEW v1 SQL SECURITY INVOKER AS SELECT * FROM t1`,
 			},
 		},
+		{
+			name: "table and column names are not case-sensitive",
+			from: `
+CREATE TABLE t1 (
+	t1_1 INT64 NOT NULL,
+	t1_2 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+`,
+			to: `
+CREATE TABLE T1 (
+	t1_1 INT64 NOT NULL,
+	T1_2 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+`,
+			expected: []string{},
+		},
 	}
 	for _, v := range values {
 		t.Run(v.name, func(t *testing.T) {


### PR DESCRIPTION
Fix: https://github.com/daichirata/hammer/issues/62

Case differences in table and column naming are no longer treated as differences.