### PR TITLE
Add support for roles

### DIFF
--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -1467,6 +1467,71 @@ CREATE TABLE T1 (
 `,
 			expected: []string{},
 		},
+		{
+			name: "create role",
+			from: `
+CREATE ROLE role1;
+`,
+			to: `
+CREATE ROLE role1;
+CREATE ROLE role2;
+`,
+			expected: []string{
+				`CREATE ROLE role2`,
+			},
+		},
+		{
+			name: "drop role",
+			from: `
+CREATE ROLE role1;
+CREATE ROLE role2;
+`,
+			to: `
+CREATE ROLE role1;
+`,
+			expected: []string{
+				`DROP ROLE role2`,
+			},
+		},
+		{
+			name: "grant role",
+			from: `
+GRANT SELECT ON TABLE T1 TO ROLE role1;
+`,
+			to: `
+GRANT SELECT ON TABLE T1 TO ROLE role1;
+GRANT SELECT ON TABLE T2 TO ROLE role2;
+`,
+			expected: []string{
+				`GRANT SELECT ON TABLE T2 TO ROLE role2`,
+			},
+		},
+		{
+			name: "revoke role",
+			from: `
+GRANT SELECT ON TABLE T1 TO ROLE role1;
+GRANT SELECT ON TABLE T2 TO ROLE role2;
+`,
+			to: `
+GRANT SELECT ON TABLE T1 TO ROLE role1;
+`,
+			expected: []string{
+				`REVOKE SELECT ON TABLE T2 FROM ROLE role2`,
+			},
+		},
+		{
+			name: "replace grant role",
+			from: `
+GRANT SELECT ON TABLE T1 TO ROLE role1;
+`,
+			to: `
+GRANT SELECT, INSERT ON TABLE T1, T2 TO ROLE role1, role2;
+`,
+			expected: []string{
+				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
+				`GRANT SELECT, INSERT ON TABLE T1, T2 TO ROLE role1, role2`,
+			},
+		},
 	}
 	for _, v := range values {
 		t.Run(v.name, func(t *testing.T) {


### PR DESCRIPTION
I added support for creating roles and granting permissions to them, which is used in Spanner's Fine Grained Access Control.

https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#role_statements
https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#grant_and_revoke_statements

Unlike tables, etc., these do not retain data internally, so as a diff, simply do a drop/revoke and then create/grant.
I'd be happy to learn of any errors in implementation policy, missing test cases, etc.