### PR TITLE
Make sure HIDDEN is added after default semantics

### DIFF
--- a/internal/hammer/ddl.go
+++ b/internal/hammer/ddl.go
@@ -80,12 +80,14 @@ func (a AlterColumn) SQL() string {
 	if a.Def.NotNull {
 		str += " NOT NULL"
 	}
+
+	if a.Def.DefaultSemantics != nil {
+		str += " " + a.Def.DefaultSemantics.SQL()
+	}
+
 	// HIDDEN will be either be 0 or invalid if not set.
 	if !a.Def.Hidden.Invalid() && a.Def.Hidden != 0 {
 		str += " HIDDEN"
-	}
-	if a.Def.DefaultSemantics != nil {
-		str += " " + a.Def.DefaultSemantics.SQL()
 	}
 
 	return str

--- a/internal/hammer/ddl_test.go
+++ b/internal/hammer/ddl_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cloudspannerecosystem/memefish/ast"
+	"github.com/cloudspannerecosystem/memefish/token"
 
 	"github.com/daichirata/hammer/internal/hammer"
 )
@@ -164,6 +165,10 @@ func TestAlterColumn_SQL(t *testing.T) {
 		{
 			d: &ast.ColumnDef{Name: newIdent("test_column"), Type: &ast.ScalarSchemaType{Name: ast.Int64TypeName}, NotNull: true, DefaultSemantics: &ast.ColumnDefaultExpr{Expr: &ast.IntLiteral{Value: "1"}}},
 			e: "ALTER TABLE test_table ALTER COLUMN test_column INT64 NOT NULL DEFAULT (1)",
+		},
+		{
+			d: &ast.ColumnDef{Name: newIdent("test_column"), Type: &ast.ScalarSchemaType{Name: ast.Int64TypeName}, NotNull: true, Hidden: token.Pos(1), DefaultSemantics: &ast.ColumnDefaultExpr{Expr: &ast.IntLiteral{Value: "1"}}},
+			e: "ALTER TABLE test_table ALTER COLUMN test_column INT64 NOT NULL DEFAULT (1) HIDDEN",
 		},
 	}
 	for _, v := range values {


### PR DESCRIPTION
Make sure HIDDEN is added after default semantics.

This would previously generate stuff like:

`ALTER TABLE MyTable ALTER COLUMN Name_Tokens TOKENLIST HIDDEN AS (TOKEN_SUBSTRING(Name))`
instead of the correct
`ALTER TABLE MyTable ALTER COLUMN Name_Tokens TOKENLIST AS (TOKEN_SUBSTRING(Name)) HIDDEN`