### PR TITLE
Fix foreign key constraint diffs for default delete action

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -807,7 +807,20 @@ func (g *Generator) columnTypeEqual(x, y *ast.ColumnDef) bool {
 }
 
 func (g *Generator) constraintEqual(x, y *ast.TableConstraint) bool {
-	return cmp.Equal(x, y, cmpopts.IgnoreTypes(token.Pos(0)))
+	return cmp.Equal(x, y,
+		cmpopts.IgnoreTypes(token.Pos(0)),
+		cmp.Comparer(func(a, b *ast.ForeignKey) bool {
+			aVal := *a
+			bVal := *b
+			if aVal.OnDelete == "" {
+				aVal.OnDelete = ast.OnDeleteNoAction
+			}
+			if bVal.OnDelete == "" {
+				bVal.OnDelete = ast.OnDeleteNoAction
+			}
+			return cmp.Equal(aVal, bVal, cmpopts.IgnoreTypes(token.Pos(0)))
+		}),
+	)
 }
 
 func (g *Generator) indexEqualIgnoringStoring(x, y *ast.CreateIndex) bool {

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -1194,6 +1194,30 @@ CREATE TABLE t2 (
 			},
 		},
 		{
+			name: "Do not recreate constraint for default delete action.",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64,
+) PRIMARY KEY(t1_1);
+
+CREATE TABLE t2 (
+  t2_1 INT64,
+  CONSTRAINT FK_t2 FOREIGN KEY (t2_1) REFERENCES t1 (t1_1) ON DELETE NO ACTION,
+) PRIMARY KEY(t2_1);
+		`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64,
+) PRIMARY KEY(t1_1);
+
+CREATE TABLE t2 (
+  t2_1 INT64,
+  CONSTRAINT FK_t2 FOREIGN KEY (t2_1) REFERENCES t1 (t1_1),
+) PRIMARY KEY(t2_1);
+		`,
+			expected: []string{},
+		},
+		{
 			name: "AlterTable add foreign key",
 			from: `
 CREATE TABLE t2 (


### PR DESCRIPTION
We tried upgrading to the latest hammer version, and suddenly all of our FK constraints were detected as changes even though nothing was different. The issue I realized is that the DDL being returned from Spanner was being interpreted with `ON DELETE NO ACTION` like `CONSTRAINT FK_Val FOREIGN KEY (Value) REFERENCES OtherTable (ValueId) ON DELETE NO ACTION`. This should be interpreted the same as `CONSTRAINT FK_Val FOREIGN KEY (Value) REFERENCES OtherTable (ValueId)` but it isn't.

This PR updates the comparison function for constraints to assume when OnDelete is empty, OnDeleteNoAction is implied.