### PR TITLE
Adding --ignore-models flag to all commands

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -38,9 +38,14 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreModels, err := cmd.Flags().GetBool("ignore-models")
+			if err != nil {
+				return err
+			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
 				IgnoreChangeStreams: ignoreChangeStreams,
+				IgnoreModels:        ignoreModels,
 			}
 
 			if hammer.Scheme(databaseURI) != "spanner" {
@@ -83,6 +88,7 @@ var (
 func init() {
 	applyCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	applyCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
+	applyCmd.Flags().Bool("ignore-models", false, "ignore model statements")
 
 	rootCmd.AddCommand(applyCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -40,9 +40,14 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreModels, err := cmd.Flags().GetBool("ignore-models")
+			if err != nil {
+				return err
+			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
 				IgnoreChangeStreams: ignoreChangeStreams,
+				IgnoreModels:        ignoreModels,
 			}
 
 			if hammer.Scheme(databaseURI) != "spanner" {
@@ -69,6 +74,7 @@ var (
 func init() {
 	createCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	createCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
+	createCmd.Flags().Bool("ignore-models", false, "ignore model statements")
 
 	rootCmd.AddCommand(createCmd)
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -44,9 +44,14 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreModels, err := cmd.Flags().GetBool("ignore-models")
+			if err != nil {
+				return err
+			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
 				IgnoreChangeStreams: ignoreChangeStreams,
+				IgnoreModels:        ignoreModels,
 			}
 
 			source1, err := hammer.NewSource(ctx, sourceURI1)
@@ -82,6 +87,7 @@ var (
 func init() {
 	diffCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	diffCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
+	diffCmd.Flags().Bool("ignore-models", false, "ignore model statements")
 
 	rootCmd.AddCommand(diffCmd)
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -37,9 +37,14 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreModels, err := cmd.Flags().GetBool("ignore-models")
+			if err != nil {
+				return err
+			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
 				IgnoreChangeStreams: ignoreChangeStreams,
+				IgnoreModels:        ignoreModels,
 			}
 
 			source, err := hammer.NewSource(ctx, sourceURI)
@@ -62,6 +67,7 @@ var (
 func init() {
 	exportCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	exportCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
+	exportCmd.Flags().Bool("ignore-models", false, "ignore model statements")
 
 	rootCmd.AddCommand(exportCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.23.2
 
 require (
 	cloud.google.com/go/spanner v1.62.0
-	github.com/cloudspannerecosystem/memefish v0.3.1
-	github.com/google/go-cmp v0.6.0
+	github.com/cloudspannerecosystem/memefish v0.6.3-0.20250823041836-b8d9bf6a877b
+	github.com/google/go-cmp v0.7.0
 	github.com/spf13/cobra v0.0.5
 	google.golang.org/api v0.180.0
 )

--- a/go.sum
+++ b/go.sum
@@ -641,10 +641,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241219043423-1efca7ff9732 h1:iGCsXdC8ourbaMC2r4tSsn3g7sLS+bEsdXs22V+GRm8=
-github.com/cloudspannerecosystem/memefish v0.0.0-20241219043423-1efca7ff9732/go.mod h1:rrHSb7mQfV8Xl47cvnE1dYJ8+zpvog49Yma0j4YCDnc=
-github.com/cloudspannerecosystem/memefish v0.3.1 h1:g3DaGE2slM5KxBlgN6+YWvEf44WB1xMrJdY27gQjDA4=
-github.com/cloudspannerecosystem/memefish v0.3.1/go.mod h1:xZ7uDI8lMlT8BF+3tmMzxdPD1TH4ZzyoiR/MNF1M3Fc=
+github.com/cloudspannerecosystem/memefish v0.6.3-0.20250823041836-b8d9bf6a877b h1:p8wkwmowagMNwYtXmjq87kemRRn4888jcfzCSr2zwcA=
+github.com/cloudspannerecosystem/memefish v0.6.3-0.20250823041836-b8d9bf6a877b/go.mod h1:9DVPxDE7QtgCb9aAfSRk7wNRp61Up3KQZS4gWbUSKRc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -772,8 +770,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -838,7 +836,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k0kubun/pp v1.3.1-0.20200204103551-99835366d1cc h1:XLjmW07gT7cG/wb6mavIrvAIWBYaTacPo8UOnxGSspA=
 github.com/k0kubun/pp/v3 v3.4.1 h1:1WdFZDRRqe8UsR61N/2RoOZ3ziTEqgTPVqKrHeb779Y=
 github.com/k0kubun/pp/v3 v3.4.1/go.mod h1:+SiNiqKnBfw1Nkj82Lh5bIeKQOAkPy6Xw9CAZUZ8npI=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=

--- a/internal/hammer/ddl.go
+++ b/internal/hammer/ddl.go
@@ -46,6 +46,9 @@ func ParseDDL(uri, schema string, option *DDLOption) (DDL, error) {
 		if _, ok := stmt.(*ast.CreateChangeStream); ok && option.IgnoreChangeStreams {
 			continue
 		}
+		if _, ok := stmt.(*ast.CreateModel); ok && option.IgnoreModels {
+			continue
+		}
 		list = append(list, stmt)
 	}
 	return DDL{List: list}, nil

--- a/internal/hammer/ddl_test.go
+++ b/internal/hammer/ddl_test.go
@@ -92,6 +92,30 @@ create change stream LongerDataRetention
   Name STRING(10) NOT NULL
 ) PRIMARY KEY (UserID);`,
 		},
+		{
+			name: "Ignore models",
+			schema: `CREATE TABLE Users (
+  UserID STRING(10) NOT NULL, -- comment
+  Name   STRING(10) NOT NULL, -- comment
+) PRIMARY KEY(UserID);
+
+CREATE MODEL GeminiFlash
+INPUT (prompt STRING(MAX))
+OUTPUT (content STRING(MAX))
+REMOTE
+OPTIONS (
+  endpoint = '//aiplatform.googleapis.com/projects/PROJECT/locations/LOCATION/publishers/google/models/MODEL',
+  default_batch_size = 1
+);
+`,
+			option: &hammer.DDLOption{
+				IgnoreModels: true,
+			},
+			want: `CREATE TABLE Users (
+  UserID STRING(10) NOT NULL,
+  Name STRING(10) NOT NULL
+) PRIMARY KEY (UserID);`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/hammer/source.go
+++ b/internal/hammer/source.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 )
 
 type Source interface {
@@ -16,6 +16,7 @@ type Source interface {
 type DDLOption struct {
 	IgnoreAlterDatabase bool
 	IgnoreChangeStreams bool
+	IgnoreModels        bool
 }
 
 func NewSource(ctx context.Context, uri string) (Source, error) {
@@ -79,7 +80,7 @@ func (s *FileSource) String() string {
 }
 
 func (s *FileSource) DDL(_ context.Context, option *DDLOption) (DDL, error) {
-	schema, err := ioutil.ReadFile(s.path)
+	schema, err := os.ReadFile(s.path)
 	if err != nil {
 		return DDL{}, err
 	}


### PR DESCRIPTION
- Hammer errors in operations on MODELs
  - Adding this flag will be backwards compatible when it is supported
- Update memefish dependency for cloudspannerecosystem/memefish#318
- Minor tweak to update deprecated `ioutil` to `os` package
