### PR TITLE
Add support for revoking before DROP and re-granting after recreate

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -1526,8 +1526,8 @@ func hasPrivilegeOnColumn(p *ast.PrivilegeOnTable, column *ast.Ident) bool {
 		return false
 	}
 	targetKey := identsToComparable(column)
-	for _, privlege := range p.Privileges {
-		switch t := privlege.(type) {
+	for _, privilege := range p.Privileges {
+		switch t := privilege.(type) {
 		case *ast.SelectPrivilege:
 			for _, c := range t.Columns {
 				if identsToComparable(c) == targetKey {

--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -490,7 +490,6 @@ func (g *Generator) generateDDLForDropConstraintIndexAndTable(table *Table) DDL 
 		if g.isDroppedGrant(grant) {
 			continue
 		}
-		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
 		g.droppedGrant = append(g.droppedGrant, grant)
 	}
 	ddl.Append(&ast.DropTable{Name: table.Name})
@@ -673,7 +672,6 @@ func (g *Generator) generateDDLForDropColumn(table *ast.Path, column *ast.Ident)
 		if g.isDroppedGrant(grant) {
 			continue
 		}
-		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
 		g.droppedGrant = append(g.droppedGrant, grant)
 	}
 
@@ -1290,7 +1288,6 @@ func (g *Generator) generateDDLForDropChangeStream(changeStream *ChangeStream) D
 		if g.isDroppedGrant(grant) {
 			continue
 		}
-		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
 		g.droppedGrant = append(g.droppedGrant, grant)
 	}
 
@@ -1322,7 +1319,6 @@ func (g *Generator) generateDDLForDropView(view *View) DDL {
 		if g.isDroppedGrant(grant) {
 			continue
 		}
-		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
 		g.droppedGrant = append(g.droppedGrant, grant)
 	}
 

--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -1349,15 +1349,15 @@ func (g *Generator) generateDDLForDropRole(role *Role) DDL {
 		if g.isDroppedGrant(grant) {
 			continue
 		}
-		// If the grant's target resource does NOT exist in "to(Database)", skip here:
-		// the object-side DROP will emit REVOKE → DROP for that resource.
+		g.droppedGrant = append(g.droppedGrant, grant)
+
+		// If the resource doesn't exist in "to(Database)", skip REVOKE:
+		// dropping the object means the grant no longer applies. Record droppedGrant only.
 		if !g.existsGrantResourceIn(grant, g.to) {
 			continue
 		}
 		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
-		g.droppedGrant = append(g.droppedGrant, grant)
 	}
-
 	ddl.Append(&ast.DropRole{
 		Name: role.Name,
 	})

--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -1427,7 +1427,7 @@ func (g *Generator) existsGrantResourceIn(grant *Grant, database *Database) bool
 
 	case *ast.ExecutePrivilegeOnTableFunction:
 		// Not tracked yet; return true so REVOKE precedes DROP ROLE (safe order).
-    	// TODO: Check existence when table functions are modeled.
+		// TODO: Check existence when table functions are modeled.
 		return true
 
 	default:

--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -118,6 +118,90 @@ type Database struct {
 	options              *ast.Options
 }
 
+func (d *Database) grantsOnTable(table *Table) []*Grant {
+	var result []*Grant
+	target := identsToComparable(table.Name.Idents...)
+
+	for _, grant := range d.grants {
+		switch p := grant.Grant.Privilege.(type) {
+		case *ast.PrivilegeOnTable:
+			for _, name := range p.Names {
+				if identsToComparable(name) == target {
+					result = append(result, grant)
+					break
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (d *Database) grantsFromPath(path *ast.Path) []*Grant {
+	var result []*Grant
+	target := identsToComparable(path.Idents...)
+
+	for _, grant := range d.grants {
+		switch p := grant.Grant.Privilege.(type) {
+		case *ast.PrivilegeOnTable:
+			for _, name := range p.Names {
+				if identsToComparable(name) == target {
+					result = append(result, grant)
+					break
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (d *Database) grantsOnView(view *View) []*Grant {
+	var result []*Grant
+	target := identsToComparable(view.Name.Idents...)
+	for _, grant := range d.grants {
+		if p, exists := grant.Grant.Privilege.(*ast.SelectPrivilegeOnView); exists {
+			for _, name := range p.Names {
+				if identsToComparable(name) == target {
+					result = append(result, grant)
+					break
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (d *Database) grantsOnChangeStream(cs *ChangeStream) []*Grant {
+	var result []*Grant
+	target := identsToComparable(cs.Name)
+
+	for _, grant := range d.grants {
+		if p, exists := grant.Grant.Privilege.(*ast.SelectPrivilegeOnChangeStream); exists {
+			for _, name := range p.Names {
+				if identsToComparable(name) == target {
+					result = append(result, grant)
+					break
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (d *Database) grantsOnRole(role *Role) []*Grant {
+	var result []*Grant
+	target := identsToComparable(role.Name)
+
+	for _, grant := range d.grants {
+		for _, r := range grant.Roles {
+			if identsToComparable(r) == target {
+				result = append(result, grant)
+				break
+			}
+		}
+	}
+	return result
+}
+
 type Table struct {
 	*ast.CreateTable
 
@@ -171,6 +255,7 @@ type Generator struct {
 	dropedIndex                      []string
 	dropedChangeStream               []string
 	droppedConstraints               []*ast.TableConstraint
+	droppedGrant                     []*Grant
 	willCreateOrAlterChangeStreamIDs map[string]*ChangeStream
 }
 
@@ -275,11 +360,18 @@ func (g *Generator) GenerateDDL() DDL {
 	// for grants
 	for _, fromGrant := range g.from.grants {
 		if _, exists := g.findGrant(g.to.grants, fromGrant); !exists {
+			if g.isDroppedGrant(fromGrant) {
+				continue
+			}
 			ddl.AppendDDL(g.generateDDLForRevokeAll(fromGrant))
 		}
 	}
 	for _, toGrant := range g.to.grants {
-		if _, exists := g.findGrant(g.from.grants, toGrant); !exists {
+		if fromGrant, exists := g.findGrant(g.from.grants, toGrant); exists {
+			if g.isDroppedGrant(fromGrant) {
+				ddl.Append(toGrant)
+			}
+		} else {
 			ddl.Append(toGrant)
 		}
 	}
@@ -393,6 +485,14 @@ func (g *Generator) generateDDLForDropConstraintIndexAndTable(table *Table) DDL 
 		}
 		return identsToComparable(fk.ReferenceTable.Idents...) == identsToComparable(table.Name.Idents...)
 	}))
+	grants := g.from.grantsOnTable(table)
+	for _, grant := range grants {
+		if g.isDroppedGrant(grant) {
+			continue
+		}
+		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
+		g.droppedGrant = append(g.droppedGrant, grant)
+	}
 	ddl.Append(&ast.DropTable{Name: table.Name})
 	g.dropedTable = append(g.dropedTable, identsToComparable(table.Name.Idents...))
 	return ddl
@@ -560,6 +660,22 @@ func (g *Generator) generateDDLForDropColumn(table *ast.Path, column *ast.Ident)
 
 		return false
 	}))
+
+	grants := g.from.grantsFromPath(table)
+	for _, grant := range grants {
+		priv, ok := grant.Grant.Privilege.(*ast.PrivilegeOnTable)
+		if !ok {
+			continue
+		}
+		if !hasPrivilegeOnColumn(priv, column) {
+			continue
+		}
+		if g.isDroppedGrant(grant) {
+			continue
+		}
+		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
+		g.droppedGrant = append(g.droppedGrant, grant)
+	}
 
 	ddl.Append(&ast.AlterTable{
 		Name:            table,
@@ -786,6 +902,15 @@ func (g *Generator) isDroppedConstraint(constraint *ast.TableConstraint) bool {
 func (g *Generator) isDropedChangeStream(name string) bool {
 	for _, t := range g.dropedChangeStream {
 		if t == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *Generator) isDroppedGrant(grant *Grant) bool {
+	for _, dg := range g.droppedGrant {
+		if equalGrant(dg, grant) {
 			return true
 		}
 	}
@@ -1159,6 +1284,16 @@ func (g *Generator) generateDDLForAlterChangeStream(from, to *ChangeStream) DDL 
 
 func (g *Generator) generateDDLForDropChangeStream(changeStream *ChangeStream) DDL {
 	ddl := DDL{}
+
+	grants := g.from.grantsOnChangeStream(changeStream)
+	for _, grant := range grants {
+		if g.isDroppedGrant(grant) {
+			continue
+		}
+		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
+		g.droppedGrant = append(g.droppedGrant, grant)
+	}
+
 	ddl.Append(&ast.DropChangeStream{Name: changeStream.Name})
 	return ddl
 }
@@ -1182,6 +1317,15 @@ func (g *Generator) generateDDLForReplaceView(view *View) DDL {
 
 func (g *Generator) generateDDLForDropView(view *View) DDL {
 	ddl := DDL{}
+	grants := g.from.grantsOnView(view)
+	for _, grant := range grants {
+		if g.isDroppedGrant(grant) {
+			continue
+		}
+		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
+		g.droppedGrant = append(g.droppedGrant, grant)
+	}
+
 	ddl.Append(&ast.DropView{Name: view.Name})
 	return ddl
 }
@@ -1203,6 +1347,21 @@ func (g *Generator) findRoleByName(roles []*Role, name string) (role *Role, exis
 
 func (g *Generator) generateDDLForDropRole(role *Role) DDL {
 	ddl := DDL{}
+	grants := g.from.grantsOnRole(role)
+
+	for _, grant := range grants {
+		if g.isDroppedGrant(grant) {
+			continue
+		}
+		// If the grant's target resource does NOT exist in "to(Database)", skip here:
+		// the object-side DROP will emit REVOKE → DROP for that resource.
+		if !g.existsGrantResourceIn(grant, g.to) {
+			continue
+		}
+		ddl.AppendDDL(g.generateDDLForRevokeAll(grant))
+		g.droppedGrant = append(g.droppedGrant, grant)
+	}
+
 	ddl.Append(&ast.DropRole{
 		Name: role.Name,
 	})
@@ -1233,6 +1392,47 @@ func (g *Generator) generateDDLForRevokeAll(grant *Grant) DDL {
 
 	ddl.Append(stmt)
 	return ddl
+}
+
+// existsGrantResourceIn returns true if any target resource of the grant exists in the given database.
+// Note: this checks resource existence (table/view/change stream…), not whether the grant itself exists.
+func (g *Generator) existsGrantResourceIn(grant *Grant, database *Database) bool {
+	if grant == nil || grant.Grant == nil || grant.Grant.Privilege == nil {
+		return false
+	}
+	switch p := grant.Grant.Privilege.(type) {
+	case *ast.PrivilegeOnTable:
+		for _, name := range p.Names {
+			if _, exists := g.findTableByName(database.tables, identsToComparable(name)); exists {
+				return true
+			}
+		}
+		return false
+
+	case *ast.SelectPrivilegeOnView:
+		for _, name := range p.Names {
+			if _, exists := g.findViewByName(database.views, identsToComparable(name)); exists {
+				return true
+			}
+		}
+		return false
+
+	case *ast.SelectPrivilegeOnChangeStream:
+		for _, name := range p.Names {
+			if _, exists := g.findChangeStreamByName(database, identsToComparable(name)); exists {
+				return true
+			}
+		}
+		return false
+
+	case *ast.ExecutePrivilegeOnTableFunction:
+		// Not tracked yet; return true so REVOKE precedes DROP ROLE (safe order).
+    	// TODO: Check existence when table functions are modeled.
+		return true
+
+	default:
+		return false
+	}
 }
 
 func equalGrant(a, b *Grant) bool {
@@ -1319,4 +1519,38 @@ func matchTablePrivilege(a, b ast.TablePrivilege) bool {
 
 func equalIdentLists(a, b []*ast.Ident) bool {
 	return identsToComparable(a...) == identsToComparable(b...)
+}
+
+func hasPrivilegeOnColumn(p *ast.PrivilegeOnTable, column *ast.Ident) bool {
+	if p == nil || column == nil {
+		return false
+	}
+	targetKey := identsToComparable(column)
+	for _, privlege := range p.Privileges {
+		switch t := privlege.(type) {
+		case *ast.SelectPrivilege:
+			for _, c := range t.Columns {
+				if identsToComparable(c) == targetKey {
+					return true
+				}
+			}
+		case *ast.InsertPrivilege:
+			for _, c := range t.Columns {
+				if identsToComparable(c) == targetKey {
+					return true
+				}
+			}
+		case *ast.UpdatePrivilege:
+			for _, c := range t.Columns {
+				if identsToComparable(c) == targetKey {
+					return true
+				}
+			}
+		case *ast.DeletePrivilege:
+			continue
+		default:
+			continue
+		}
+	}
+	return false
 }

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -2011,26 +2011,6 @@ CREATE TABLE T1 (
 			},
 		},
 		{
-			name: "grant on view resource",
-			from: ``,
-			to: `
-				GRANT SELECT ON VIEW V1 TO ROLE role1;
-			`,
-			expected: []string{
-				`GRANT SELECT ON VIEW V1 TO ROLE role1`,
-			},
-		},
-		{
-			name: "grant on change stream",
-			from: ``,
-			to: `
-				GRANT SELECT ON CHANGE STREAM cs1 TO ROLE role1;
-			`,
-			expected: []string{
-				`GRANT SELECT ON CHANGE STREAM cs1 TO ROLE role1`,
-			},
-		},
-		{
 			name: "grant multiple privileges at once",
 			from: ``,
 			to: `
@@ -2214,6 +2194,24 @@ CREATE TABLE T1 (
 			expected: []string{
 				`REVOKE SELECT ON CHANGE STREAM CS1 FROM ROLE role1`,
 				`DROP ROLE role1`,
+			},
+		},
+		{
+			name: "drop role: revoke only for resources that remain in target",
+			from: `
+				CREATE ROLE role1;
+				CREATE TABLE T1 (id INT64);
+				CREATE TABLE T2 (id INT64);
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+				GRANT SELECT ON TABLE T2 TO ROLE role1;
+			`,
+			to: `
+				CREATE TABLE T1 (id INT64);
+			`,
+			expected: []string{
+				`DROP TABLE T2`,
+				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
+				`DROP ROLE role1`,  
 			},
 		},
 	}

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -2053,6 +2053,176 @@ CREATE TABLE T1 (
 				`GRANT SELECT(col1, col2) ON TABLE T1 TO ROLE role1`,
 			},
 		},
+		{
+			name: "revoke on table before DROP TABLE",
+			from: `
+				CREATE ROLE role1;
+				CREATE TABLE T1 (id INT64);
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+			`,
+			to: `
+				CREATE ROLE role1;
+			`,
+			expected: []string{
+				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
+				`DROP TABLE T1`,
+			},
+		},
+		{
+			name: "revoke on table before DROP TABLE (PK change triggers drop)",
+			from: `
+				CREATE ROLE role1;
+				CREATE TABLE T1 (id INT64,name STRING(100)) PRIMARY KEY(id);
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+			`,
+			to: `
+				CREATE ROLE role1;
+				CREATE TABLE T1 (id INT64,name STRING(100)) PRIMARY KEY(name);
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+			`,
+			expected: []string{
+				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
+				`DROP TABLE T1`,
+				"CREATE TABLE T1 (\n  id INT64,\n  name STRING(100)\n) PRIMARY KEY (name)",
+				`GRANT SELECT ON TABLE T1 TO ROLE role1`,
+			},
+		},
+		{
+			name: "revoke on table before DROP TABLE (interleave parent changed)",
+			from: `
+				CREATE ROLE role1;
+				CREATE TABLE P1 (pid INT64 NOT NULL) PRIMARY KEY(pid);
+				CREATE TABLE P2 (pid INT64 NOT NULL) PRIMARY KEY(pid);
+				CREATE TABLE T1 (id INT64 NOT NULL) PRIMARY KEY(id), INTERLEAVE IN PARENT P1;
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+			`,
+			to: `
+				CREATE ROLE role1;
+				CREATE TABLE P1 (pid INT64 NOT NULL) PRIMARY KEY(pid);
+				CREATE TABLE P2 (pid INT64 NOT NULL) PRIMARY KEY(pid);
+				CREATE TABLE T1 (id INT64 NOT NULL) PRIMARY KEY(id), INTERLEAVE IN PARENT P2;
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+			`,
+			expected: []string{
+				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
+				`DROP TABLE T1`,
+				"CREATE TABLE T1 (\n  id INT64 NOT NULL\n) PRIMARY KEY (id),\n  INTERLEAVE IN PARENT P2",
+				`GRANT SELECT ON TABLE T1 TO ROLE role1`,
+			},
+		},
+		{
+			name: "revoke on table before DROP TABLE (removing interleave)",
+			from: `
+				CREATE ROLE role1;
+				CREATE TABLE P1 (pid INT64 NOT NULL) PRIMARY KEY(pid);
+				CREATE TABLE T1 (id INT64 NOT NULL) PRIMARY KEY(id), INTERLEAVE IN PARENT P1;
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+			`,
+			to: `
+				CREATE ROLE role1;
+				CREATE TABLE P1 (pid INT64 NOT NULL) PRIMARY KEY(pid);
+				CREATE TABLE T1 (id INT64 NOT NULL) PRIMARY KEY(id);
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+			`,
+			expected: []string{
+				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
+				`DROP TABLE T1`,
+				"CREATE TABLE T1 (\n  id INT64 NOT NULL\n) PRIMARY KEY (id)",
+				`GRANT SELECT ON TABLE T1 TO ROLE role1`,
+			},
+		},
+		{
+			name: "revoke on column before DROP COLUMN",
+			from: `
+				CREATE ROLE role1;
+				CREATE TABLE T1 (id INT64, name STRING(100));
+				GRANT SELECT(name) ON TABLE T1 TO ROLE role1;
+			`,
+			to: `
+				CREATE ROLE role1;
+				CREATE TABLE T1 (id INT64);
+			`,
+			expected: []string{
+				`REVOKE SELECT(name) ON TABLE T1 FROM ROLE role1`,
+				`ALTER TABLE T1 DROP COLUMN name`,
+			},
+		},
+		{
+			name: "revoke on view before DROP VIEW",
+			from: `
+				CREATE ROLE role1;
+				CREATE VIEW V1 SQL SECURITY INVOKER AS SELECT 1;
+				GRANT SELECT ON VIEW V1 TO ROLE role1;
+			`,
+			to: `
+				CREATE ROLE role1;
+			`,
+			expected: []string{
+				`REVOKE SELECT ON VIEW V1 FROM ROLE role1`,
+				`DROP VIEW V1`,
+			},
+		},
+		{
+			name: "revoke on change stream before DROP CHANGE STREAM",
+			from: `
+				CREATE ROLE role1;
+				CREATE CHANGE STREAM CS1 FOR ALL;
+				GRANT SELECT ON CHANGE STREAM CS1 TO ROLE role1;
+			`,
+			to: `
+				CREATE ROLE role1;
+			`,
+			expected: []string{
+				`REVOKE SELECT ON CHANGE STREAM CS1 FROM ROLE role1`,
+				`DROP CHANGE STREAM CS1`,
+			},
+		},
+		{
+			name: "revoke table grant before DROP ROLE",
+			from: `
+				CREATE ROLE role1;
+				CREATE TABLE T1 (id INT64);
+				GRANT SELECT ON TABLE T1 TO ROLE role1;
+			`,
+			to: `
+				CREATE TABLE T1 (id INT64);
+			`,
+			expected: []string{
+				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
+				`DROP ROLE role1`,
+			},
+		},
+		{
+			name: "revoke view grant before DROP ROLE",
+			from: `
+				CREATE ROLE role1;
+				CREATE VIEW V1 SQL SECURITY INVOKER AS SELECT 1;
+				GRANT SELECT ON VIEW V1 TO ROLE role1;
+			`,
+			to: `
+				CREATE VIEW V1 SQL SECURITY INVOKER AS SELECT 1;
+			`,
+			expected: []string{
+				`CREATE OR REPLACE VIEW V1 SQL SECURITY INVOKER AS SELECT 1`,
+				`REVOKE SELECT ON VIEW V1 FROM ROLE role1`,
+				`DROP ROLE role1`,
+			},
+		},
+		{
+			name: "revoke change stream grant before DROP ROLE",
+			from: `
+				CREATE ROLE role1;
+				CREATE CHANGE STREAM CS1 FOR ALL;
+				GRANT SELECT ON CHANGE STREAM CS1 TO ROLE role1;
+			`,
+			to: `
+				CREATE CHANGE STREAM CS1 FOR ALL;
+			`,
+			expected: []string{
+				`REVOKE SELECT ON CHANGE STREAM CS1 FROM ROLE role1`,
+				`DROP ROLE role1`,
+			},
+		},
 	}
 	for _, v := range values {
 		t.Run(v.name, func(t *testing.T) {

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -2064,7 +2064,6 @@ CREATE TABLE T1 (
 				CREATE ROLE role1;
 			`,
 			expected: []string{
-				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
 				`DROP TABLE T1`,
 			},
 		},
@@ -2081,7 +2080,6 @@ CREATE TABLE T1 (
 				GRANT SELECT ON TABLE T1 TO ROLE role1;
 			`,
 			expected: []string{
-				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
 				`DROP TABLE T1`,
 				"CREATE TABLE T1 (\n  id INT64,\n  name STRING(100)\n) PRIMARY KEY (name)",
 				`GRANT SELECT ON TABLE T1 TO ROLE role1`,
@@ -2104,7 +2102,6 @@ CREATE TABLE T1 (
 				GRANT SELECT ON TABLE T1 TO ROLE role1;
 			`,
 			expected: []string{
-				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
 				`DROP TABLE T1`,
 				"CREATE TABLE T1 (\n  id INT64 NOT NULL\n) PRIMARY KEY (id),\n  INTERLEAVE IN PARENT P2",
 				`GRANT SELECT ON TABLE T1 TO ROLE role1`,
@@ -2125,7 +2122,6 @@ CREATE TABLE T1 (
 				GRANT SELECT ON TABLE T1 TO ROLE role1;
 			`,
 			expected: []string{
-				`REVOKE SELECT ON TABLE T1 FROM ROLE role1`,
 				`DROP TABLE T1`,
 				"CREATE TABLE T1 (\n  id INT64 NOT NULL\n) PRIMARY KEY (id)",
 				`GRANT SELECT ON TABLE T1 TO ROLE role1`,
@@ -2143,7 +2139,6 @@ CREATE TABLE T1 (
 				CREATE TABLE T1 (id INT64);
 			`,
 			expected: []string{
-				`REVOKE SELECT(name) ON TABLE T1 FROM ROLE role1`,
 				`ALTER TABLE T1 DROP COLUMN name`,
 			},
 		},
@@ -2158,7 +2153,6 @@ CREATE TABLE T1 (
 				CREATE ROLE role1;
 			`,
 			expected: []string{
-				`REVOKE SELECT ON VIEW V1 FROM ROLE role1`,
 				`DROP VIEW V1`,
 			},
 		},
@@ -2173,7 +2167,6 @@ CREATE TABLE T1 (
 				CREATE ROLE role1;
 			`,
 			expected: []string{
-				`REVOKE SELECT ON CHANGE STREAM CS1 FROM ROLE role1`,
 				`DROP CHANGE STREAM CS1`,
 			},
 		},


### PR DESCRIPTION
## Summary
Revoke before DROP; re-grant after recreate when the grant remains in the target schema.

## Motivation
Diffs can fail due to ordering (e.g., REVOKE after DROP or table drop+recreate). This PR makes it explicit: revoke before DROP, re-grant after recreate if the grant remains, aligning privileges with existing DROP flows (indexes/search indexes/change streams/constraints).