### PR TITLE
fix: ignore CREATE PROTO BUNDLE rather than error

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -92,6 +92,8 @@ func NewDatabase(ddl DDL) (*Database, error) {
 			roles = append(roles, &Role{CreateRole: stmt})
 		case *ast.Grant:
 			grants = append(grants, &Grant{Grant: stmt})
+		case *ast.CreateProtoBundle:
+			// CREATE PROTO BUNDLE is not supported, ignore it.
 		default:
 			return nil, fmt.Errorf("unexpected ddl statement: %v", stmt.SQL())
 		}

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -2634,6 +2634,52 @@ CREATE CHANGE STREAM CS2 FOR t2;
 				"DROP TABLE t1",
 			},
 		},
+		{
+			name: "ignore create proto bundle in from",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE PROTO BUNDLE (foo.bar);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+`,
+			expected: []string{},
+		},
+		{
+			name: "ignore create proto bundle in to",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE PROTO BUNDLE (foo.bar);
+`,
+			expected: []string{},
+		},
+		{
+			name: "ignore create proto bundle in both",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE PROTO BUNDLE (foo.bar);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE PROTO BUNDLE (foo.bar, baz.qux);
+`,
+			expected: []string{},
+		},
 	}
 	for _, v := range values {
 		t.Run(v.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `NewDatabase` previously returned an error when encountering a `CREATE PROTO BUNDLE` statement, making it impossible to use hammer with schemas that include proto bundles
- Adds a no-op case for `*ast.CreateProtoBundle` so the statement is silently skipped during diff generation
- Proto bundle diffing is not supported; bundles are intentionally excluded from the output
