### PR TITLE
Fix spurious diffs from omitted defaults and slice ordering

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -994,7 +994,23 @@ func (g *Generator) isDroppedGrant(grant *Grant) bool {
 }
 
 func (g *Generator) interleaveEqual(x, y *Table) bool {
-	return cmp.Equal(x.Cluster, y.Cluster, cmpopts.IgnoreTypes(token.Pos(0)))
+	return cmp.Equal(x.Cluster, y.Cluster,
+		cmpopts.IgnoreTypes(token.Pos(0)),
+		cmp.Comparer(func(a, b *ast.Cluster) bool {
+			if a == nil || b == nil {
+				return a == b
+			}
+			aVal := *a
+			bVal := *b
+			if aVal.OnDelete == "" {
+				aVal.OnDelete = ast.OnDeleteNoAction
+			}
+			if bVal.OnDelete == "" {
+				bVal.OnDelete = ast.OnDeleteNoAction
+			}
+			return cmp.Equal(aVal, bVal, cmpopts.IgnoreTypes(token.Pos(0)))
+		}),
+	)
 }
 
 func (g *Generator) primaryKeyEqual(x, y *Table) bool {
@@ -1062,6 +1078,12 @@ func (g *Generator) constraintEqual(x, y *ast.TableConstraint) bool {
 			if bVal.OnDelete == "" {
 				bVal.OnDelete = ast.OnDeleteNoAction
 			}
+			if aVal.Enforcement == "" {
+				aVal.Enforcement = ast.Enforced
+			}
+			if bVal.Enforcement == "" {
+				bVal.Enforcement = ast.Enforced
+			}
 			return cmp.Equal(aVal, bVal, cmpopts.IgnoreTypes(token.Pos(0)))
 		}),
 	)
@@ -1071,6 +1093,7 @@ func (g *Generator) indexEqualIgnoringStoring(x, y *ast.CreateIndex) bool {
 	return cmp.Equal(x, y,
 		cmpopts.IgnoreTypes(token.Pos(0)),
 		cmpopts.IgnoreTypes(&ast.Storing{}),
+		cmpopts.IgnoreFields(ast.CreateIndex{}, "IfNotExists"),
 		cmp.Comparer(func(a, b *ast.IndexKey) bool {
 			aVal := *a
 			bVal := *b
@@ -1086,11 +1109,32 @@ func (g *Generator) indexEqualIgnoringStoring(x, y *ast.CreateIndex) bool {
 }
 
 func (g *Generator) searchIndexEqual(x, y ast.CreateSearchIndex) bool {
-	return cmp.Equal(x, y, cmpopts.IgnoreTypes(token.Pos(0)))
+	return cmp.Equal(x, y,
+		cmpopts.IgnoreTypes(token.Pos(0)),
+		cmp.Comparer(func(a, b *ast.OrderByItem) bool {
+			aVal := *a
+			bVal := *b
+			if aVal.Dir == "" {
+				aVal.Dir = ast.DirectionAsc
+			}
+			if bVal.Dir == "" {
+				bVal.Dir = ast.DirectionAsc
+			}
+			return cmp.Equal(aVal, bVal, cmpopts.IgnoreTypes(token.Pos(0)))
+		}),
+	)
 }
 
 func (g *Generator) changeStreamForEqual(x, y ast.ChangeStreamFor) bool {
-	return cmp.Equal(x, y, cmpopts.IgnoreTypes(token.Pos(0)))
+	return cmp.Equal(x, y,
+		cmpopts.IgnoreTypes(token.Pos(0)),
+		cmpopts.SortSlices(func(a, b *ast.ChangeStreamForTable) bool {
+			return identsToComparable(a.TableName) < identsToComparable(b.TableName)
+		}),
+		cmpopts.SortSlices(func(a, b *ast.Ident) bool {
+			return identsToComparable(a) < identsToComparable(b)
+		}),
+	)
 }
 
 func (g *Generator) columnDefaultExprEqual(x, y ast.ColumnDefaultSemantics) bool {
@@ -1102,7 +1146,18 @@ func (g *Generator) createRowDeletionPolicyEqual(x, y *ast.CreateRowDeletionPoli
 }
 
 func (g *Generator) optionsEqual(x, y *ast.Options) bool {
-	return cmp.Equal(x, y, cmpopts.IgnoreTypes(token.Pos(0)))
+	return cmp.Equal(g.optionsToMap(x), g.optionsToMap(y))
+}
+
+func (g *Generator) optionsToMap(options *ast.Options) map[string]string {
+	if options == nil {
+		return nil
+	}
+	m := make(map[string]string, len(options.Records))
+	for _, o := range options.Records {
+		m[o.Name.Name] = o.Value.SQL()
+	}
+	return m
 }
 
 func (g *Generator) optionsValueEqual(x, y *ast.Options, name string) bool {

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -2635,6 +2635,327 @@ CREATE CHANGE STREAM CS2 FOR t2;
 			},
 		},
 		{
+			name: "interleave on delete no action is the default (explicit to implicit)",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t1_1 INT64 NOT NULL,
+  t2_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1, t2_1), INTERLEAVE IN PARENT t1 ON DELETE NO ACTION;
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t1_1 INT64 NOT NULL,
+  t2_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1, t2_1), INTERLEAVE IN PARENT t1;
+`,
+			expected: []string{},
+		},
+		{
+			name: "interleave on delete no action is the default (implicit to explicit)",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t1_1 INT64 NOT NULL,
+  t2_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1, t2_1), INTERLEAVE IN PARENT t1;
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t1_1 INT64 NOT NULL,
+  t2_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1, t2_1), INTERLEAVE IN PARENT t1 ON DELETE NO ACTION;
+`,
+			expected: []string{},
+		},
+		{
+			name: "interleave on delete cascade is detected as a real change",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t1_1 INT64 NOT NULL,
+  t2_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1, t2_1), INTERLEAVE IN PARENT t1;
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t1_1 INT64 NOT NULL,
+  t2_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1, t2_1), INTERLEAVE IN PARENT t1 ON DELETE CASCADE;
+`,
+			expected: []string{
+				"DROP TABLE t2",
+				"CREATE TABLE t2 (\n  t1_1 INT64 NOT NULL,\n  t2_1 INT64 NOT NULL\n) PRIMARY KEY (t1_1, t2_1),\n  INTERLEAVE IN PARENT t1 ON DELETE CASCADE",
+			},
+		},
+		{
+			name: "foreign key enforced is the default (explicit to implicit)",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t2_1 INT64 NOT NULL,
+  t2_2 INT64,
+  CONSTRAINT FK_t2 FOREIGN KEY (t2_2) REFERENCES t1 (t1_1) ENFORCED,
+) PRIMARY KEY(t2_1);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t2_1 INT64 NOT NULL,
+  t2_2 INT64,
+  CONSTRAINT FK_t2 FOREIGN KEY (t2_2) REFERENCES t1 (t1_1),
+) PRIMARY KEY(t2_1);
+`,
+			expected: []string{},
+		},
+		{
+			name: "foreign key enforced is the default (implicit to explicit)",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t2_1 INT64 NOT NULL,
+  t2_2 INT64,
+  CONSTRAINT FK_t2 FOREIGN KEY (t2_2) REFERENCES t1 (t1_1),
+) PRIMARY KEY(t2_1);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t2_1 INT64 NOT NULL,
+  t2_2 INT64,
+  CONSTRAINT FK_t2 FOREIGN KEY (t2_2) REFERENCES t1 (t1_1) ENFORCED,
+) PRIMARY KEY(t2_1);
+`,
+			expected: []string{},
+		},
+		{
+			name: "foreign key not enforced is detected as a real change",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t2_1 INT64 NOT NULL,
+  t2_2 INT64,
+  CONSTRAINT FK_t2 FOREIGN KEY (t2_2) REFERENCES t1 (t1_1),
+) PRIMARY KEY(t2_1);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE TABLE t2 (
+  t2_1 INT64 NOT NULL,
+  t2_2 INT64,
+  CONSTRAINT FK_t2 FOREIGN KEY (t2_2) REFERENCES t1 (t1_1) NOT ENFORCED,
+) PRIMARY KEY(t2_1);
+`,
+			expected: []string{
+				"ALTER TABLE t2 DROP CONSTRAINT FK_t2",
+				"ALTER TABLE t2 ADD CONSTRAINT FK_t2 FOREIGN KEY (t2_2) REFERENCES t1 (t1_1) NOT ENFORCED",
+			},
+		},
+		{
+			name: "search index order by ASC is the default (explicit to implicit)",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1 ASC;
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1;
+`,
+			expected: []string{},
+		},
+		{
+			name: "search index order by ASC is the default (implicit to explicit)",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1;
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1 ASC;
+`,
+			expected: []string{},
+		},
+		{
+			name: "search index order by DESC is detected as a real change",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1;
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1 DESC;
+`,
+			expected: []string{
+				"DROP SEARCH INDEX idx_t1",
+				"CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1 DESC",
+			},
+		},
+		{
+			name: "create index IF NOT EXISTS is ignored when comparing (explicit to implicit)",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 INT64,
+) PRIMARY KEY(t1_1);
+CREATE INDEX IF NOT EXISTS idx_t1 ON t1(t1_2);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 INT64,
+) PRIMARY KEY(t1_1);
+CREATE INDEX idx_t1 ON t1(t1_2);
+`,
+			expected: []string{},
+		},
+		{
+			name: "create index IF NOT EXISTS is ignored when comparing (implicit to explicit)",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 INT64,
+) PRIMARY KEY(t1_1);
+CREATE INDEX idx_t1 ON t1(t1_2);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 INT64,
+) PRIMARY KEY(t1_1);
+CREATE INDEX IF NOT EXISTS idx_t1 ON t1(t1_2);
+`,
+			expected: []string{},
+		},
+		{
+			name: "change stream FOR tables order does not matter",
+			from: `
+CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE TABLE t2 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1, t2;
+`,
+			to: `
+CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE TABLE t2 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t2, t1;
+`,
+			expected: []string{},
+		},
+		{
+			name: "change stream FOR table column order does not matter",
+			from: `
+CREATE TABLE t1 (
+  id INT64 NOT NULL,
+  a INT64,
+  b INT64,
+) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1(a, b);
+`,
+			to: `
+CREATE TABLE t1 (
+  id INT64 NOT NULL,
+  a INT64,
+  b INT64,
+) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1(b, a);
+`,
+			expected: []string{},
+		},
+		{
+			name: "change stream FOR tables change is still detected",
+			from: `
+CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE TABLE t2 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE TABLE t3 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1, t2;
+`,
+			to: `
+CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE TABLE t2 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE TABLE t3 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1, t3;
+`,
+			expected: []string{
+				"ALTER CHANGE STREAM cs SET FOR t1, t3",
+			},
+		},
+		{
+			name: "change stream OPTIONS order does not matter",
+			from: `
+CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1 OPTIONS (retention_period = '7d', value_capture_type = 'NEW_VALUES');
+`,
+			to: `
+CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1 OPTIONS (value_capture_type = 'NEW_VALUES', retention_period = '7d');
+`,
+			expected: []string{},
+		},
+		{
+			name: "change stream OPTIONS value change is still detected",
+			from: `
+CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1 OPTIONS (retention_period = '7d', value_capture_type = 'NEW_VALUES');
+`,
+			to: `
+CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY(id);
+CREATE CHANGE STREAM cs FOR t1 OPTIONS (retention_period = '14d', value_capture_type = 'NEW_VALUES');
+`,
+			expected: []string{
+				`ALTER CHANGE STREAM cs SET OPTIONS (retention_period = "14d", value_capture_type = "NEW_VALUES")`,
+			},
+		},
+		{
 			name: "ignore create proto bundle in from",
 			from: `
 CREATE TABLE t1 (


### PR DESCRIPTION
## Summary

After the memefish migration (v0.7.0-beta), the AST preserves whether the user wrote optional clauses explicitly or omitted them. Spanner's `GetDdl` (and inconsistent local SQL files) sometimes omits values that are the default, which causes hammer to emit spurious DDL. This PR fixes the six cases I could reproduce.

### Spurious DDL fixes

1. **`INTERLEAVE IN PARENT` `ON DELETE NO ACTION` (default)** — previously emitted `DROP TABLE` + `CREATE TABLE` when one side had the clause explicit and the other omitted. **Most severe — data loss.**
2. **`FOREIGN KEY ... ENFORCED` (default)** — previously emitted `DROP CONSTRAINT` + `ADD CONSTRAINT`. Same pattern as the existing `OnDelete` normalization in `constraintEqual`.
3. **`CREATE SEARCH INDEX ... ORDER BY col ASC` (default)** — previously emitted `DROP SEARCH INDEX` + `CREATE SEARCH INDEX`. Same pattern as the existing `IndexKey.Dir` normalization from #66.
4. **`CREATE INDEX IF NOT EXISTS`** — previously emitted `DROP INDEX` + `CREATE INDEX` every time when one side wrote `IF NOT EXISTS` (since `GetDdl` never returns it).
5. **`CREATE CHANGE STREAM FOR t1, t2`** — table/column order is semantically a set; previously emitted a spurious `ALTER CHANGE STREAM SET FOR` whenever the order differed.
6. **`CREATE CHANGE STREAM ... OPTIONS (...)`** — option records are an unordered map; previously emitted a spurious `ALTER CHANGE STREAM SET OPTIONS` whenever the order differed. Now compared the same way `generateDDLForAlterDatabaseOptions` already does (name → SQL-value map).

### How

- `interleaveEqual`: normalize `Cluster.OnDelete` `""` → `ON DELETE NO ACTION` (with nil guard).
- `constraintEqual`: extend the existing `*ast.ForeignKey` comparer to also normalize `Enforcement` `""` → `ENFORCED`.
- `searchIndexEqual`: add a comparer that normalizes `OrderByItem.Dir` `""` → `ASC`.
- `indexEqualIgnoringStoring`: ignore `CreateIndex.IfNotExists` via `cmpopts.IgnoreFields`.
- `changeStreamForEqual`: sort `ChangeStreamForTable` lists and column ident lists via `cmpopts.SortSlices`.
- `optionsEqual`: compare via `optionsToMap` (`name` → `value.SQL()`), making it order-insensitive.

## Test plan

- [x] Added paired tests for each fix: explicit↔implicit (no diff) and a control case proving a real change is still detected.
- [x] `go test -race ./...` passes locally.