### PR TITLE
Replace silent CREATE PROTO BUNDLE ignore with --ignore-proto-bundles flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ apply, create, diff and export can accept the flags defined below
 --ignore-alter-database   ignore alter database statements
 --ignore-change-streams   ignore change streams statements
 --ignore-models           ignore model statements
+--ignore-proto-bundles    ignore proto bundle statements
 ```
 
 ### Examples

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -42,10 +42,15 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreProtoBundles, err := cmd.Flags().GetBool("ignore-proto-bundles")
+			if err != nil {
+				return err
+			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
 				IgnoreChangeStreams: ignoreChangeStreams,
 				IgnoreModels:        ignoreModels,
+				IgnoreProtoBundles:  ignoreProtoBundles,
 			}
 
 			if hammer.Scheme(databaseURI) != "spanner" {
@@ -89,6 +94,7 @@ func init() {
 	applyCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	applyCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
 	applyCmd.Flags().Bool("ignore-models", false, "ignore model statements")
+	applyCmd.Flags().Bool("ignore-proto-bundles", false, "ignore proto bundle statements")
 
 	rootCmd.AddCommand(applyCmd)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -44,10 +44,15 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreProtoBundles, err := cmd.Flags().GetBool("ignore-proto-bundles")
+			if err != nil {
+				return err
+			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
 				IgnoreChangeStreams: ignoreChangeStreams,
 				IgnoreModels:        ignoreModels,
+				IgnoreProtoBundles:  ignoreProtoBundles,
 			}
 
 			if hammer.Scheme(databaseURI) != "spanner" {
@@ -75,6 +80,7 @@ func init() {
 	createCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	createCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
 	createCmd.Flags().Bool("ignore-models", false, "ignore model statements")
+	createCmd.Flags().Bool("ignore-proto-bundles", false, "ignore proto bundle statements")
 
 	rootCmd.AddCommand(createCmd)
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -48,10 +48,15 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreProtoBundles, err := cmd.Flags().GetBool("ignore-proto-bundles")
+			if err != nil {
+				return err
+			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
 				IgnoreChangeStreams: ignoreChangeStreams,
 				IgnoreModels:        ignoreModels,
+				IgnoreProtoBundles:  ignoreProtoBundles,
 			}
 
 			source1, err := hammer.NewSource(ctx, sourceURI1)
@@ -88,6 +93,7 @@ func init() {
 	diffCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	diffCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
 	diffCmd.Flags().Bool("ignore-models", false, "ignore model statements")
+	diffCmd.Flags().Bool("ignore-proto-bundles", false, "ignore proto bundle statements")
 
 	rootCmd.AddCommand(diffCmd)
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -41,10 +41,15 @@ var (
 			if err != nil {
 				return err
 			}
+			ignoreProtoBundles, err := cmd.Flags().GetBool("ignore-proto-bundles")
+			if err != nil {
+				return err
+			}
 			ddlOption := &hammer.DDLOption{
 				IgnoreAlterDatabase: ignoreAlterDatabase,
 				IgnoreChangeStreams: ignoreChangeStreams,
 				IgnoreModels:        ignoreModels,
+				IgnoreProtoBundles:  ignoreProtoBundles,
 			}
 
 			source, err := hammer.NewSource(ctx, sourceURI)
@@ -68,6 +73,7 @@ func init() {
 	exportCmd.Flags().Bool("ignore-alter-database", false, "ignore alter database statements")
 	exportCmd.Flags().Bool("ignore-change-streams", false, "ignore change streams statements")
 	exportCmd.Flags().Bool("ignore-models", false, "ignore model statements")
+	exportCmd.Flags().Bool("ignore-proto-bundles", false, "ignore proto bundle statements")
 
 	rootCmd.AddCommand(exportCmd)
 }

--- a/internal/hammer/ddl.go
+++ b/internal/hammer/ddl.go
@@ -49,6 +49,9 @@ func ParseDDL(uri, schema string, option *DDLOption) (DDL, error) {
 		if _, ok := stmt.(*ast.CreateModel); ok && option.IgnoreModels {
 			continue
 		}
+		if _, ok := stmt.(*ast.CreateProtoBundle); ok && option.IgnoreProtoBundles {
+			continue
+		}
 		list = append(list, stmt)
 	}
 	return DDL{List: list}, nil

--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -91,8 +91,6 @@ func NewDatabase(ddl DDL) (*Database, error) {
 			roles = append(roles, &Role{CreateRole: stmt})
 		case *ast.Grant:
 			grants = append(grants, &Grant{Grant: stmt})
-		case *ast.CreateProtoBundle:
-			// CREATE PROTO BUNDLE is not supported, ignore it.
 		default:
 			return nil, fmt.Errorf("unexpected ddl statement: %v", stmt.SQL())
 		}

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -18,6 +18,7 @@ func TestDiff(t *testing.T) {
 		from                string
 		to                  string
 		ignoreAlterDatabase bool
+		ignoreProtoBundles  bool
 		expected            []string
 	}{
 		// === TABLE ===
@@ -3552,7 +3553,8 @@ CREATE TABLE t1 (
   t1_1 INT64 NOT NULL,
 ) PRIMARY KEY(t1_1);
 `,
-			expected: []string{},
+			ignoreProtoBundles: true,
+			expected:           []string{},
 		},
 		{
 			name: "ignore create proto bundle in to",
@@ -3567,7 +3569,8 @@ CREATE TABLE t1 (
 ) PRIMARY KEY(t1_1);
 CREATE PROTO BUNDLE (foo.bar);
 `,
-			expected: []string{},
+			ignoreProtoBundles: true,
+			expected:           []string{},
 		},
 		{
 			name: "ignore create proto bundle in both",
@@ -3583,7 +3586,8 @@ CREATE TABLE t1 (
 ) PRIMARY KEY(t1_1);
 CREATE PROTO BUNDLE (foo.bar, baz.qux);
 `,
-			expected: []string{},
+			ignoreProtoBundles: true,
+			expected:           []string{},
 		},
 		// === IDENTIFIERS / NAMING ===
 		{
@@ -3643,11 +3647,11 @@ CREATE TABLE T1 (
 		t.Run(v.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			d1, err := StringSource(v.from).DDL(ctx, &hammer.DDLOption{IgnoreAlterDatabase: v.ignoreAlterDatabase})
+			d1, err := StringSource(v.from).DDL(ctx, &hammer.DDLOption{IgnoreAlterDatabase: v.ignoreAlterDatabase, IgnoreProtoBundles: v.ignoreProtoBundles})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			d2, err := StringSource(v.to).DDL(ctx, &hammer.DDLOption{IgnoreAlterDatabase: v.ignoreAlterDatabase})
+			d2, err := StringSource(v.to).DDL(ctx, &hammer.DDLOption{IgnoreAlterDatabase: v.ignoreAlterDatabase, IgnoreProtoBundles: v.ignoreProtoBundles})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/hammer/source.go
+++ b/internal/hammer/source.go
@@ -17,6 +17,7 @@ type DDLOption struct {
 	IgnoreAlterDatabase bool
 	IgnoreChangeStreams bool
 	IgnoreModels        bool
+	IgnoreProtoBundles  bool
 }
 
 func NewSource(ctx context.Context, uri string) (Source, error) {


### PR DESCRIPTION
## Summary

CREATE PROTO BUNDLE was silently dropped in `NewDatabase`, while the analogous unsupported statement `CREATE MODEL` required users to opt in via the `--ignore-models` flag. This PR unifies the two patterns under the explicit-opt-in approach by introducing `--ignore-proto-bundles`.

## Problem with the silent path

```go
// Before (internal/hammer/diff.go)
case *ast.CreateProtoBundle:
    // CREATE PROTO BUNDLE is not supported, ignore it.
```

This has two issues:

- Users can't tell that hammer just stripped a statement from their schema, so a `CREATE PROTO BUNDLE` typo or paste mistake never produces an error.
- If hammer later grows real `CREATE PROTO BUNDLE` support, schemas that relied on the silent drop will suddenly start emitting diffs the user never asked for.

## Changes

- `DDLOption` gains an `IgnoreProtoBundles bool` field.
- `ParseDDL` filters `*ast.CreateProtoBundle` when the flag is set, matching the existing `*ast.CreateModel` handling.
- The silent `case *ast.CreateProtoBundle:` in `NewDatabase` is removed, so the statement now falls through to the default `unexpected ddl statement` error path.
- `--ignore-proto-bundles` is added to `apply` / `create` / `diff` / `export`.
- The three `ignore create proto bundle in {from,to,both}` tests set `ignoreProtoBundles: true` and continue to verify the flag's behaviour.
- README's Flags section lists the new flag.
