### PR TITLE
Add JSON_QUERY generated column tests

### DIFF
--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -591,6 +591,45 @@ CREATE TABLE t1 (
 			},
 		},
 		{
+			name: "generated column with JSON_QUERY identity is no-op",
+			from: `
+CREATE TABLE t1 (
+  id STRING(40) NOT NULL,
+  data JSON,
+  has_value BOOL AS (IF(JSON_QUERY(data, '$.value') IS NOT NULL, true, false)) STORED,
+) PRIMARY KEY(id);
+`,
+			to: `
+CREATE TABLE t1 (
+  id STRING(40) NOT NULL,
+  data JSON,
+  has_value BOOL AS (IF(JSON_QUERY(data, '$.value') IS NOT NULL, true, false)) STORED,
+) PRIMARY KEY(id);
+`,
+			expected: []string{},
+		},
+		{
+			name: "generated column with JSON_QUERY path change is detected",
+			from: `
+CREATE TABLE t1 (
+  id STRING(40) NOT NULL,
+  data JSON,
+  has_value BOOL AS (IF(JSON_QUERY(data, '$.value') IS NOT NULL, true, false)) STORED,
+) PRIMARY KEY(id);
+`,
+			to: `
+CREATE TABLE t1 (
+  id STRING(40) NOT NULL,
+  data JSON,
+  has_value BOOL AS (IF(JSON_QUERY(data, '$.other') IS NOT NULL, true, false)) STORED,
+) PRIMARY KEY(id);
+`,
+			expected: []string{
+				`ALTER TABLE t1 DROP COLUMN has_value`,
+				`ALTER TABLE t1 ADD COLUMN has_value BOOL AS (IF(JSON_QUERY(data, "$.other") IS NOT NULL, TRUE, FALSE)) STORED`,
+			},
+		},
+		{
 			name: "change column (interleaved)",
 			from: `
 CREATE TABLE t1 (


### PR DESCRIPTION
## Summary

Refs #55.

The original report ("JSON_QUERY not recognized") was caused by the old spansql-based parser and was already resolved by the spansql → memefish migration in #66, but the suite had no test that locked the behaviour in. This PR adds two regression tests:

- **`generated column with JSON_QUERY identity is no-op`** asserts hammer parses and round-trips a generated column whose expression uses `JSON_QUERY`.
- **`generated column with JSON_QUERY path change is detected`** asserts hammer detects the difference and emits `DROP COLUMN` + `ADD COLUMN` when the JSON path string is changed.

No production code changes.

## Spanner verification

Verified end-to-end against a real Cloud Spanner instance:

- `hammer apply` of the schema with `BOOL AS (IF(JSON_QUERY(data, '$.value') IS NOT NULL, true, false)) STORED` succeeds.
- `hammer diff` between the local file and `GetDdl` output is empty (round-trip is clean).
- Changing the JSON path produces the expected `DROP COLUMN` / `ADD COLUMN` pair, and `hammer apply` of that diff succeeds.

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] Real Spanner round-trip and path-change apply both succeed.