### PR TITLE
Drop indexes before dropping STORING / PARTITION BY / ORDER BY columns

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -835,7 +835,7 @@ func (g *Generator) generateDDLForDropIndex(from, to *Table) DDL {
 	for _, toIndex := range to.searchIndexes {
 		fromIndex, exists := g.findSearchIndexByName(from.searchIndexes, identsToComparable(toIndex.Name))
 
-		if exists && !g.searchIndexEqual(*fromIndex, *toIndex) {
+		if exists && !g.searchIndexEqual(fromIndex, toIndex) {
 			ddl.Append(&ast.DropSearchIndex{Name: fromIndex.Name})
 			g.dropedIndex = append(g.dropedIndex, identsToComparable(fromIndex.Name))
 		}
@@ -864,7 +864,7 @@ func (g *Generator) generateDDLForCreateIndex(from, to *Table) DDL {
 	for _, toIndex := range to.searchIndexes {
 		fromIndex, exists := g.findSearchIndexByName(from.searchIndexes, identsToComparable(toIndex.Name))
 
-		if !exists || !g.searchIndexEqual(*fromIndex, *toIndex) {
+		if !exists || !g.searchIndexEqual(fromIndex, toIndex) {
 			ddl.Append(toIndex)
 		}
 	}
@@ -1141,7 +1141,7 @@ func (g *Generator) indexEqualIgnoringStoring(x, y *ast.CreateIndex) bool {
 	)
 }
 
-func (g *Generator) searchIndexEqual(x, y ast.CreateSearchIndex) bool {
+func (g *Generator) searchIndexEqual(x, y *ast.CreateSearchIndex) bool {
 	return cmp.Equal(x, y,
 		cmpopts.IgnoreTypes(token.Pos(0)),
 		cmp.Comparer(func(a, b *ast.OrderByItem) bool {
@@ -1336,14 +1336,27 @@ func (g *Generator) findIndexByName(indexes []*ast.CreateIndex, name string) (in
 func (g *Generator) findIndexByColumn(indexes []*ast.CreateIndex, column string) []*ast.CreateIndex {
 	result := []*ast.CreateIndex{}
 	for _, i := range indexes {
-		for _, c := range i.Keys {
-			if identsToComparable(c.Name) == column {
-				result = append(result, i)
-				break
-			}
+		if indexReferencesColumn(i, column) {
+			result = append(result, i)
 		}
 	}
 	return result
+}
+
+func indexReferencesColumn(i *ast.CreateIndex, column string) bool {
+	for _, k := range i.Keys {
+		if identsToComparable(k.Name) == column {
+			return true
+		}
+	}
+	if i.Storing != nil {
+		for _, c := range i.Storing.Columns {
+			if identsToComparable(c) == column {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (g *Generator) findSearchIndexByName(indexes []*ast.CreateSearchIndex, name string) (index *ast.CreateSearchIndex, exists bool) {
@@ -1358,14 +1371,39 @@ func (g *Generator) findSearchIndexByName(indexes []*ast.CreateSearchIndex, name
 func (g *Generator) findSearchIndexByColumn(indexes []*ast.CreateSearchIndex, column string) []*ast.CreateSearchIndex {
 	result := []*ast.CreateSearchIndex{}
 	for _, i := range indexes {
-		for _, c := range i.TokenListPart {
-			if c.Name == column {
-				result = append(result, i)
-				break
-			}
+		if searchIndexReferencesColumn(i, column) {
+			result = append(result, i)
 		}
 	}
 	return result
+}
+
+func searchIndexReferencesColumn(i *ast.CreateSearchIndex, column string) bool {
+	for _, c := range i.TokenListPart {
+		if identsToComparable(c) == column {
+			return true
+		}
+	}
+	if i.Storing != nil {
+		for _, c := range i.Storing.Columns {
+			if identsToComparable(c) == column {
+				return true
+			}
+		}
+	}
+	for _, c := range i.PartitionColumns {
+		if identsToComparable(c) == column {
+			return true
+		}
+	}
+	if i.OrderBy != nil {
+		for _, item := range i.OrderBy.Items {
+			if id, ok := item.Expr.(*ast.Ident); ok && identsToComparable(id) == column {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (g *Generator) generateDDLForDropNamedConstraintsMatchingPredicate(predicate func(table *Table, constraint *ast.TableConstraint) bool) DDL {

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -1971,6 +1971,31 @@ CREATE INDEX IF NOT EXISTS idx_t1 ON t1(t1_2);
 `,
 			expected: []string{},
 		},
+		{
+			name: "index follows STORING column drop+create",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 INT64 NOT NULL,
+  t1_3 INT64,
+) PRIMARY KEY(t1_1);
+CREATE INDEX idx_t1 ON t1(t1_2) STORING (t1_3);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 INT64 NOT NULL,
+  t1_3 STRING(MAX),
+) PRIMARY KEY(t1_1);
+CREATE INDEX idx_t1 ON t1(t1_2) STORING (t1_3);
+`,
+			expected: []string{
+				"DROP INDEX idx_t1",
+				"ALTER TABLE t1 DROP COLUMN t1_3",
+				"ALTER TABLE t1 ADD COLUMN t1_3 STRING(MAX)",
+				"CREATE INDEX idx_t1 ON t1(t1_2) STORING (t1_3)",
+			},
+		},
 		// === SEARCH INDEX ===
 		{
 			name: "add search index",
@@ -2155,6 +2180,89 @@ CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1 DESC;
 			expected: []string{
 				"DROP SEARCH INDEX idx_t1",
 				"CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_1 DESC",
+			},
+		},
+		{
+			name: "search index follows STORING column drop+create",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+  t1_4 INT64,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) STORING (t1_4);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+  t1_4 STRING(MAX),
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) STORING (t1_4);
+`,
+			expected: []string{
+				"DROP SEARCH INDEX idx_t1",
+				"ALTER TABLE t1 DROP COLUMN t1_4",
+				"ALTER TABLE t1 ADD COLUMN t1_4 STRING(MAX)",
+				"CREATE SEARCH INDEX idx_t1 ON t1(t1_3) STORING (t1_4)",
+			},
+		},
+		{
+			name: "search index follows PARTITION BY column drop+create",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+  t1_4 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) PARTITION BY t1_4;
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+  t1_4 STRING(MAX) NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) PARTITION BY t1_4;
+`,
+			expected: []string{
+				"DROP SEARCH INDEX idx_t1",
+				"ALTER TABLE t1 DROP COLUMN t1_4",
+				`ALTER TABLE t1 ADD COLUMN t1_4 STRING(MAX) NOT NULL DEFAULT ("")`,
+				"ALTER TABLE t1 ALTER COLUMN t1_4 DROP DEFAULT",
+				"CREATE SEARCH INDEX idx_t1 ON t1(t1_3) PARTITION BY t1_4",
+			},
+		},
+		{
+			name: "search index follows ORDER BY column drop+create",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+  t1_4 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_4 DESC;
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 STRING(MAX) NOT NULL,
+  t1_3 TOKENLIST AS (TOKENIZE_FULLTEXT(t1_2)) HIDDEN,
+  t1_4 STRING(MAX) NOT NULL,
+) PRIMARY KEY(t1_1);
+CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_4 DESC;
+`,
+			expected: []string{
+				"DROP SEARCH INDEX idx_t1",
+				"ALTER TABLE t1 DROP COLUMN t1_4",
+				`ALTER TABLE t1 ADD COLUMN t1_4 STRING(MAX) NOT NULL DEFAULT ("")`,
+				"ALTER TABLE t1 ALTER COLUMN t1_4 DROP DEFAULT",
+				"CREATE SEARCH INDEX idx_t1 ON t1(t1_3) ORDER BY t1_4 DESC",
 			},
 		},
 		// === VIEW ===


### PR DESCRIPTION
## Summary

hammer detects which indexes reference a column that is about to be dropped so it can emit `DROP INDEX` before `ALTER TABLE ... DROP COLUMN`. Without that, Spanner rejects the column drop:

```
ERROR: Cannot drop column t1_3 from table hmt_storing_test
       because it is used by index hmt_idx_t1.
```

The existing detectors were incomplete: `findIndexByColumn` only inspected `CreateIndex.Keys`, and `findSearchIndexByColumn` only inspected `CreateSearchIndex.TokenListPart`. Columns referenced **only** via `STORING`, `PARTITION BY` or `ORDER BY` were silently missed, so hammer would emit `ALTER TABLE ... DROP COLUMN` with no preceding `DROP INDEX`, and `hammer apply` would fail with the error above. Verified on a real Cloud Spanner instance against the current master.

## Changes

- Extract `indexReferencesColumn` / `searchIndexReferencesColumn` helpers that walk every position a column can appear in:
  - Regular `CREATE INDEX`: `Keys`, `Storing.Columns`.
  - `CREATE SEARCH INDEX`: `TokenListPart`, `Storing.Columns`, `PartitionColumns`, simple-column references in `OrderBy.Items`.
- Both helpers compare via the existing `identsToComparable` so any future case-folding decision propagates automatically.
- Realign `searchIndexEqual` with the surrounding `*Equal` helpers by taking `*ast.CreateSearchIndex` instead of a value receiver. The two call sites no longer need to dereference.

## Tests

Four regression tests, all asserting that hammer emits `DROP INDEX` before the column type change and recreates the index after:

- `index follows STORING column drop+create` (regular CREATE INDEX, STORING column).
- `search index follows STORING column drop+create`.
- `search index follows PARTITION BY column drop+create`.
- `search index follows ORDER BY column drop+create`.

## Spanner verification

End-to-end on a real Cloud Spanner instance:

- Before the fix: `ALTER TABLE ... DROP COLUMN t1_3` (no `DROP INDEX`) is rejected by Spanner with `Cannot drop column t1_3 from table ... because it is used by index ...`.
- After the fix: hammer emits `DROP INDEX → DROP COLUMN → ADD COLUMN → CREATE INDEX`, Spanner accepts the sequence, and the column type change applies cleanly.

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] Real Cloud Spanner round-trip succeeds.