### PR TITLE
Drop foreign keys before changing NOT NULL on referenced columns

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -695,8 +695,12 @@ func (g *Generator) generateDDLForColumns(from, to *Table) DDL {
 			}
 		}
 		if g.columnTypeEqual(fromCol, toCol) && !requireDropAndCreateByDefault(fromCol.DefaultSemantics) && !requireDropAndCreateByDefault(toCol.DefaultSemantics) {
+			notNullChanged := fromCol.NotNull != toCol.NotNull
 			if st, ok := fromCol.Type.(*ast.ScalarSchemaType); ok && st.Name == ast.TimestampTypeName {
-				if fromCol.NotNull != toCol.NotNull || !g.columnDefaultExprEqual(fromCol.DefaultSemantics, toCol.DefaultSemantics) {
+				if notNullChanged || !g.columnDefaultExprEqual(fromCol.DefaultSemantics, toCol.DefaultSemantics) {
+					if notNullChanged {
+						ddl.AppendDDL(g.generateDDLForDropForeignKeysReferencingColumn(to.Name, toCol.Name))
+					}
 					if !fromCol.NotNull && toCol.NotNull {
 						ddl.Append(Update{Table: to.Name.SQL(), Def: toCol})
 					}
@@ -706,6 +710,9 @@ func (g *Generator) generateDDLForColumns(from, to *Table) DDL {
 					ddl.Append(AlterColumn{Table: to.Name.SQL(), Def: toCol, SetOptions: true})
 				}
 			} else {
+				if notNullChanged {
+					ddl.AppendDDL(g.generateDDLForDropForeignKeysReferencingColumn(to.Name, toCol.Name))
+				}
 				if !fromCol.NotNull && toCol.NotNull {
 					ddl.Append(Update{Table: to.Name.SQL(), Def: toCol})
 				}
@@ -723,33 +730,16 @@ func (g *Generator) generateDDLForColumns(from, to *Table) DDL {
 	return ddl
 }
 
+func (g *Generator) generateDDLForDropForeignKeysReferencingColumn(table *ast.Path, column *ast.Ident) DDL {
+	return g.generateDDLForDropNamedConstraintsMatchingPredicate(func(t *Table, constraint *ast.TableConstraint) bool {
+		return foreignKeyReferencesColumn(t, table, column, constraint)
+	})
+}
+
 func (g *Generator) generateDDLForDropColumn(table *ast.Path, column *ast.Ident) DDL {
 	ddl := DDL{}
 
-	ddl.AppendDDL(g.generateDDLForDropNamedConstraintsMatchingPredicate(func(t *Table, constraint *ast.TableConstraint) bool {
-		fk, ok := constraint.Constraint.(*ast.ForeignKey)
-		if !ok {
-			return false
-		}
-
-		if identsToComparable(t.Name.Idents...) == identsToComparable(table.Idents...) {
-			for _, c := range fk.Columns {
-				if identsToComparable(column) == identsToComparable(c) {
-					return true
-				}
-			}
-		}
-
-		if identsToComparable(fk.ReferenceTable.Idents...) == identsToComparable(table.Idents...) {
-			for _, refColumn := range fk.ReferenceColumns {
-				if identsToComparable(column) == identsToComparable(refColumn) {
-					return true
-				}
-			}
-		}
-
-		return false
-	}))
+	ddl.AppendDDL(g.generateDDLForDropForeignKeysReferencingColumn(table, column))
 
 	grants := g.from.grantsFromPath(table)
 	for _, grant := range grants {
@@ -1376,6 +1366,29 @@ func (g *Generator) findSearchIndexByColumn(indexes []*ast.CreateSearchIndex, co
 		}
 	}
 	return result
+}
+
+func foreignKeyReferencesColumn(constraintHost *Table, tableName *ast.Path, column *ast.Ident, constraint *ast.TableConstraint) bool {
+	fk, ok := constraint.Constraint.(*ast.ForeignKey)
+	if !ok {
+		return false
+	}
+	columnKey := identsToComparable(column)
+	if identsToComparable(constraintHost.Name.Idents...) == identsToComparable(tableName.Idents...) {
+		for _, c := range fk.Columns {
+			if identsToComparable(c) == columnKey {
+				return true
+			}
+		}
+	}
+	if identsToComparable(fk.ReferenceTable.Idents...) == identsToComparable(tableName.Idents...) {
+		for _, refColumn := range fk.ReferenceColumns {
+			if identsToComparable(refColumn) == columnKey {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func searchIndexReferencesColumn(i *ast.CreateSearchIndex, column string) bool {

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -374,6 +374,161 @@ CREATE TABLE t1 (
 			},
 		},
 		{
+			name: "drop NOT NULL on FK column drops and re-adds the constraint",
+			from: `
+CREATE TABLE Bars (
+  ID INT64 NOT NULL,
+) PRIMARY KEY(ID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  BarID INT64 NOT NULL,
+  CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID),
+) PRIMARY KEY(FooID);
+`,
+			to: `
+CREATE TABLE Bars (
+  ID INT64 NOT NULL,
+) PRIMARY KEY(ID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  BarID INT64,
+  CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID),
+) PRIMARY KEY(FooID);
+`,
+			expected: []string{
+				`ALTER TABLE Foos DROP CONSTRAINT FK_FoosBar`,
+				`ALTER TABLE Foos ALTER COLUMN BarID INT64`,
+				`ALTER TABLE Foos ADD CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID)`,
+			},
+		},
+		{
+			name: "add NOT NULL on FK column drops and re-adds the constraint",
+			from: `
+CREATE TABLE Bars (
+  ID INT64 NOT NULL,
+) PRIMARY KEY(ID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  BarID INT64,
+  CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID),
+) PRIMARY KEY(FooID);
+`,
+			to: `
+CREATE TABLE Bars (
+  ID INT64 NOT NULL,
+) PRIMARY KEY(ID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  BarID INT64 NOT NULL,
+  CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID),
+) PRIMARY KEY(FooID);
+`,
+			expected: []string{
+				`ALTER TABLE Foos DROP CONSTRAINT FK_FoosBar`,
+				`UPDATE Foos SET BarID = 0 WHERE BarID IS NULL`,
+				`ALTER TABLE Foos ALTER COLUMN BarID INT64 NOT NULL`,
+				`ALTER TABLE Foos ADD CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID)`,
+			},
+		},
+		{
+			name: "drop NOT NULL on a column referenced by FK from another table",
+			from: `
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  RefKey INT64 NOT NULL,
+) PRIMARY KEY(FooID);
+CREATE TABLE Bazs (
+  BazID INT64 NOT NULL,
+  RefKey INT64 NOT NULL,
+  CONSTRAINT FK_BazsFoos FOREIGN KEY (RefKey) REFERENCES Foos (RefKey),
+) PRIMARY KEY(BazID);
+`,
+			to: `
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  RefKey INT64,
+) PRIMARY KEY(FooID);
+CREATE TABLE Bazs (
+  BazID INT64 NOT NULL,
+  RefKey INT64 NOT NULL,
+  CONSTRAINT FK_BazsFoos FOREIGN KEY (RefKey) REFERENCES Foos (RefKey),
+) PRIMARY KEY(BazID);
+`,
+			expected: []string{
+				`ALTER TABLE Bazs DROP CONSTRAINT FK_BazsFoos`,
+				`ALTER TABLE Foos ALTER COLUMN RefKey INT64`,
+				`ALTER TABLE Bazs ADD CONSTRAINT FK_BazsFoos FOREIGN KEY (RefKey) REFERENCES Foos (RefKey)`,
+			},
+		},
+		{
+			name: "FK column unchanged is no-op",
+			from: `
+CREATE TABLE Bars (
+  ID INT64 NOT NULL,
+) PRIMARY KEY(ID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  BarID INT64 NOT NULL,
+  CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID),
+) PRIMARY KEY(FooID);
+`,
+			to: `
+CREATE TABLE Bars (
+  ID INT64 NOT NULL,
+) PRIMARY KEY(ID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  BarID INT64 NOT NULL,
+  CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID),
+) PRIMARY KEY(FooID);
+`,
+			expected: []string{},
+		},
+		{
+			name: "DEFAULT change on FK column does not drop the constraint",
+			from: `
+CREATE TABLE Bars (
+  ID INT64 NOT NULL,
+) PRIMARY KEY(ID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  BarID INT64 NOT NULL DEFAULT (1),
+  CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID),
+) PRIMARY KEY(FooID);
+`,
+			to: `
+CREATE TABLE Bars (
+  ID INT64 NOT NULL,
+) PRIMARY KEY(ID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  BarID INT64 NOT NULL DEFAULT (2),
+  CONSTRAINT FK_FoosBar FOREIGN KEY (BarID) REFERENCES Bars (ID),
+) PRIMARY KEY(FooID);
+`,
+			expected: []string{
+				`ALTER TABLE Foos ALTER COLUMN BarID INT64 NOT NULL DEFAULT (2)`,
+			},
+		},
+		{
+			name: "NOT NULL change on a column without FK does not emit FK ops",
+			from: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 INT64 NOT NULL,
+) PRIMARY KEY(t1_1);
+`,
+			to: `
+CREATE TABLE t1 (
+  t1_1 INT64 NOT NULL,
+  t1_2 INT64,
+) PRIMARY KEY(t1_1);
+`,
+			expected: []string{
+				`ALTER TABLE t1 ALTER COLUMN t1_2 INT64`,
+			},
+		},
+		{
 			name: "change column (timestamp)",
 			from: `
 CREATE TABLE t1 (


### PR DESCRIPTION
## Summary

Closes #32.

Spanner rejects `ALTER TABLE ... ALTER COLUMN col TYPE` when the column participates in any foreign key:

```
Cannot change the nullability for column `BarID` of table `Foos`.
It is used by one or more foreign keys: `FK_FoosBar`.
```

Until now hammer happily emitted exactly that statement, so `hammer apply` failed at runtime whenever a user toggled `NOT NULL` on an FK-referenced column. Confirmed against a live Cloud Spanner instance on master.

## Fix

Mirror the existing drop-column handling: identify every foreign key that references the column (either on the same table via `fk.Columns`, or on another table via `fk.ReferenceColumns`), emit `ALTER TABLE ... DROP CONSTRAINT` for each, run the `ALTER COLUMN`, and let the existing constraint diff loop re-add the FK at the end of the table's processing.

- Extract `foreignKeyReferencesColumn` and `generateDDLForDropForeignKeysReferencingColumn` so the predicate is shared between the drop-column path and the new alter-column path.
- Use a single `notNullChanged` local in `generateDDLForColumns` so the `!=` gate appears once per branch instead of being duplicated.

## Tests

Positive cases:

- `drop NOT NULL on FK column drops and re-adds the constraint` — the original report scenario.
- `add NOT NULL on FK column drops and re-adds the constraint` — covers the UPDATE-before-alter path.
- `drop NOT NULL on a column referenced by FK from another table` — FK on a different table that points at this column.

Negative controls (assert we don't over-trigger):

- `FK column unchanged is no-op` — no schema change at all.
- `DEFAULT change on FK column does not drop the constraint` — only the column DEFAULT changes; FK must stay.
- `NOT NULL change on a column without FK does not emit FK ops` — a plain ALTER COLUMN when no FK is in scope.

## Spanner verification

Real Cloud Spanner round-trip for the original-report shape:

- Master: emits `ALTER TABLE Foos ALTER COLUMN BarID INT64`; Spanner returns `Cannot change the nullability ... used by one or more foreign keys: FK_FoosBar`.
- This branch: emits `DROP CONSTRAINT FK_FoosBar → ALTER COLUMN → ADD CONSTRAINT FK_FoosBar`; Spanner accepts the sequence and the table ends up with the requested nullability.

## Out of scope

A separate Spanner restriction prevents `ALTER COLUMN col TYPE` if the column is also covered by a `UNIQUE INDEX`. That's a different cleanup path (drop and recreate the unique index) and not part of this PR.

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] Real Cloud Spanner apply succeeds on the original-report scenario after this fix.