### PR TITLE
Defer constraint diff until after all per-table column changes

### DIFF
--- a/internal/hammer/diff.go
+++ b/internal/hammer/diff.go
@@ -267,6 +267,7 @@ func (g *Generator) GenerateDDL() DDL {
 	ddl.AppendDDL(g.generateDDLForAlterDatabaseOptions())
 
 	// for alter table
+	var constraintTargets []*Table
 	for _, toTable := range g.to.tables {
 		fromTable, exists := g.findTableByName(g.from.tables, identsToComparable(toTable.Name.Idents...))
 
@@ -296,9 +297,13 @@ func (g *Generator) GenerateDDL() DDL {
 		ddl.AppendDDL(g.generateDDLForColumns(fromTable, toTable))
 		ddl.AppendDDL(g.generateDDLForCreateIndex(fromTable, toTable))
 		ddl.AppendDDL(g.generateDDLForAlterIndex(fromTable, toTable))
-		ddl.AppendDDL(g.generateDDLForConstraints(fromTable, toTable))
+		constraintTargets = append(constraintTargets, toTable)
 		ddl.AppendDDL(g.generateDDLForRowDeletionPolicy(fromTable, toTable))
 		ddl.AppendDDL(g.generateDDLForCreateChangeStream(g.from, toTable))
+	}
+	for _, toTable := range constraintTargets {
+		fromTable, _ := g.findTableByName(g.from.tables, identsToComparable(toTable.Name.Idents...))
+		ddl.AppendDDL(g.generateDDLForConstraints(fromTable, toTable))
 	}
 	// for alter change stream
 	for _, toChangeStream := range g.to.changeStreams {

--- a/internal/hammer/diff_test.go
+++ b/internal/hammer/diff_test.go
@@ -461,6 +461,36 @@ CREATE TABLE Bazs (
 			},
 		},
 		{
+			name: "drop NOT NULL when FK on another table is declared before the column owner",
+			from: `
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  RefKey INT64 NOT NULL,
+) PRIMARY KEY(FooID);
+CREATE TABLE Bazs (
+  BazID INT64 NOT NULL,
+  RefKey INT64 NOT NULL,
+  CONSTRAINT FK_BazsFoos FOREIGN KEY (RefKey) REFERENCES Foos (RefKey),
+) PRIMARY KEY(BazID);
+`,
+			to: `
+CREATE TABLE Bazs (
+  BazID INT64 NOT NULL,
+  RefKey INT64 NOT NULL,
+  CONSTRAINT FK_BazsFoos FOREIGN KEY (RefKey) REFERENCES Foos (RefKey),
+) PRIMARY KEY(BazID);
+CREATE TABLE Foos (
+  FooID INT64 NOT NULL,
+  RefKey INT64,
+) PRIMARY KEY(FooID);
+`,
+			expected: []string{
+				`ALTER TABLE Bazs DROP CONSTRAINT FK_BazsFoos`,
+				`ALTER TABLE Foos ALTER COLUMN RefKey INT64`,
+				`ALTER TABLE Bazs ADD CONSTRAINT FK_BazsFoos FOREIGN KEY (RefKey) REFERENCES Foos (RefKey)`,
+			},
+		},
+		{
 			name: "FK column unchanged is no-op",
 			from: `
 CREATE TABLE Bars (


### PR DESCRIPTION
## Summary

Follow-up to #97.

PR #97 made hammer drop the foreign key when toggling `NOT NULL` on the column it references, but missed a table-ordering case. When the FK is declared on a table that appears **before** the column owner in the `to` schema, the per-table loop in `GenerateDDL` ran the FK host's constraint phase first; the FK was then dropped during a later table's column processing, and the re-add never ran because the host table's constraint loop had already completed.

## Reproduction

`from`:

```sql
CREATE TABLE Foos (
  FooID INT64 NOT NULL,
  RefKey INT64 NOT NULL,
) PRIMARY KEY(FooID);
CREATE TABLE Bazs (
  BazID INT64 NOT NULL,
  RefKey INT64 NOT NULL,
  CONSTRAINT FK_BazsFoos FOREIGN KEY (RefKey) REFERENCES Foos (RefKey),
) PRIMARY KEY(BazID);
```

`to` (same content, but **Bazs declared before Foos** and `Foos.RefKey` now nullable):

```sql
CREATE TABLE Bazs (
  BazID INT64 NOT NULL,
  RefKey INT64 NOT NULL,
  CONSTRAINT FK_BazsFoos FOREIGN KEY (RefKey) REFERENCES Foos (RefKey),
) PRIMARY KEY(BazID);
CREATE TABLE Foos (
  FooID INT64 NOT NULL,
  RefKey INT64,
) PRIMARY KEY(FooID);
```

`hammer diff` on master (post-#97) emits:

```sql
ALTER TABLE Bazs DROP CONSTRAINT FK_BazsFoos;
ALTER TABLE Foos ALTER COLUMN RefKey INT64;
```

The matching `ADD CONSTRAINT` is silently dropped because Bazs's constraint phase already finished before Foos's column processing.

## Fix

Pull `generateDDLForConstraints` out of the per-table loop into a second pass that runs after every table's columns / indexes have been processed. The first pass records the to tables that survived recreation, and the second pass replays the constraint diff for each in to-schema order. Any FK dropped during a later table's column processing is therefore re-added on its owning table, regardless of declaration order.

Add a regression test (`drop NOT NULL when FK on another table is declared before the column owner`) that pins the corrected ordering.

## Test plan

- [x] `go test -race ./...` passes locally.